### PR TITLE
Alembic setup, cascade-deletion for foreign keys, delete subcommand

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ htmlcov/
 test-reports/
 samples/2024-11-01-12-34-id.yml
 samples/new_receipt.yml
+samples/receipt-[12].yml
 
 # Typing coverage and Pylint
 .mypy_cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,5 +9,6 @@ and we adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Database migration support using Alembic through a subcommand added.
 - Initial version with database schema creation and YAML file reading/writing 
   for database import.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,7 @@ and we adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Database migration support using Alembic through a subcommand added.
 - Initial version with database schema creation and YAML file reading/writing 
   for database import.
+
+### Changed
+
+- Add cascade deletes for receipt products/discounts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and we adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Receipt file and database entry deletion through a subcommand added.
 - Database migration support using Alembic through a subcommand added.
 - Initial version with database schema creation and YAML file reading/writing 
   for database import.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include requirements.txt
+include rechu/alembic.ini
 include rechu/py.typed

--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ YAML files from the defined path and subdirectory pattern with `rechu read`;
 you can later use the same command to synchronize changes in YAML files to the 
 database.
 
+When you install a new version of this package, there may be database schema 
+changes. You should run `rechu alembic upgrade head` to migrate your database 
+to the proper version. This command will use the database connection configured 
+in your `settings.toml` file.
+
 Some additional scripts that do not use the database are available in the 
 `scripts` directory in the repository. These are mostly meant for experiments, 
 simple reporting and validation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ authors = [{name = "Leon Helwerda", email = "leon.helwerda@gmail.com"}]
 license = {text = "MIT"}
 requires-python = ">=3.9"
 dependencies = [
+    "alembic==1.14.1",
     "python-dateutil==2.9.0.post0",
     "PyYAML==6.0.2",
     "SQLAlchemy==2.0.36",
@@ -45,3 +46,6 @@ include = ["rechu*"]
 
 [tool.setuptools.package-data]
 "rechu" = ["py.typed"]
+
+[tool.pylint]
+ignored-modules = ["alembic"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,8 @@ dependencies = [
     "python-dateutil==2.9.0.post0",
     "PyYAML==6.0.2",
     "SQLAlchemy==2.0.36",
-    "tomlkit==0.13.2"
+    "tomlkit==0.13.2",
+    "typing_extensions==4.12.2"
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",

--- a/rechu/__main__.py
+++ b/rechu/__main__.py
@@ -10,13 +10,7 @@ def main() -> None:
     Main entry point for receipt subcommands.
     """
 
-    if len(sys.argv) <= 1:
-        raise RuntimeError('Usage: python -m rechu <command>')
-
-    name = sys.argv[1]
-
-    command = Base.get_command(name)
-    command.run()
+    Base.start(sys.executable, sys.argv)
 
 if __name__ == "__main__":
     main()

--- a/rechu/alembic.ini
+++ b/rechu/alembic.ini
@@ -1,0 +1,120 @@
+# A generic, single database configuration.
+
+[alembic]
+# path to migration scripts
+# Use forward slashes (/) also on windows to provide an os agnostic path
+script_location = rechu/alembic
+
+# template used to generate migration file names; The default value is %%(rev)s_%%(slug)s
+# Uncomment the line below if you want the files to be prepended with date and time
+# see https://alembic.sqlalchemy.org/en/latest/tutorial.html#editing-the-ini-file
+# for all available tokens
+# file_template = %%(year)d_%%(month).2d_%%(day).2d_%%(hour).2d%%(minute).2d-%%(rev)s_%%(slug)s
+
+# sys.path path, will be prepended to sys.path if present.
+# defaults to the current working directory.
+prepend_sys_path = .
+
+# timezone to use when rendering the date within the migration file
+# as well as the filename.
+# If specified, requires the python>=3.9 or backports.zoneinfo library and tzdata library.
+# Any required deps can installed by adding `alembic[tz]` to the pip requirements
+# string value is passed to ZoneInfo()
+# leave blank for localtime
+# timezone =
+
+# max length of characters to apply to the "slug" field
+# truncate_slug_length = 40
+
+# set to 'true' to run the environment during
+# the 'revision' command, regardless of autogenerate
+# revision_environment = false
+
+# set to 'true' to allow .pyc and .pyo files without
+# a source .py file to be detected as revisions in the
+# versions/ directory
+# sourceless = false
+
+# version location specification; This defaults
+# to alembic/versions.  When using multiple version
+# directories, initial revisions must be specified with --version-path.
+# The path separator used here should be the separator specified by "version_path_separator" below.
+# version_locations = %(here)s/bar:%(here)s/bat:alembic/versions
+
+# version path separator; As mentioned above, this is the character used to split
+# version_locations. The default within new alembic.ini files is "os", which uses os.pathsep.
+# If this key is omitted entirely, it falls back to the legacy behavior of splitting on spaces and/or commas.
+# Valid values for version_path_separator are:
+#
+# version_path_separator = :
+# version_path_separator = ;
+# version_path_separator = space
+# version_path_separator = newline
+#
+# Use os.pathsep. Default configuration used for new projects.
+version_path_separator = os
+
+# set to 'true' to search source files recursively
+# in each "version_locations" directory
+# new in Alembic version 1.10
+# recursive_version_locations = false
+
+# the output encoding used when revision files
+# are written from script.py.mako
+# output_encoding = utf-8
+
+# We obtain the database URI from rechu settings in alembic/env.py
+# sqlalchemy.url = driver://user:pass@localhost/dbname
+
+
+[post_write_hooks]
+# post_write_hooks defines scripts or Python functions that are run
+# on newly generated revision scripts.  See the documentation for further
+# detail and examples
+
+# format using "black" - use the console_scripts runner, against the "black" entrypoint
+# hooks = black
+# black.type = console_scripts
+# black.entrypoint = black
+# black.options = -l 79 REVISION_SCRIPT_FILENAME
+
+# lint with attempts to fix using "ruff" - use the exec runner, execute a binary
+# hooks = ruff
+# ruff.type = exec
+# ruff.executable = %(here)s/.venv/bin/ruff
+# ruff.options = --fix REVISION_SCRIPT_FILENAME
+
+# Logging configuration
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARNING
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARNING
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/rechu/alembic/README
+++ b/rechu/alembic/README
@@ -1,0 +1,1 @@
+Generic single-database configuration.

--- a/rechu/alembic/env.py
+++ b/rechu/alembic/env.py
@@ -34,19 +34,17 @@ TARGET_METADATA = Base.metadata
 # my_important_option = config.get_main_option("my_important_option")
 # ... etc.
 
-
 def run_migrations_offline() -> None:
-    """Run migrations in 'offline' mode.
-
-    This configures the context with just a URL
-    and not an Engine, though an Engine is acceptable
-    here as well.  By skipping the Engine creation
-    we don't even need a DBAPI to be available.
-
-    Calls to context.execute() here emit the given string to the
-    script output.
-
     """
+    Run migrations in 'offline' mode.
+
+    This configures the context with just a URL and not an Engine, though an
+    Engine is acceptable here as well. By skipping the Engine creation we don't
+    even need a DBAPI to be available.
+
+    Calls to context.execute() here emit the given string to the script output.
+    """
+
     settings = Settings.get_settings()
     url = settings.get("database", "uri")
     context.configure(
@@ -54,19 +52,18 @@ def run_migrations_offline() -> None:
         target_metadata=TARGET_METADATA,
         render_as_batch=True,
         literal_binds=True,
-        dialect_opts={"paramstyle": "named"},
+        dialect_opts={"paramstyle": "named"}
     )
 
     with context.begin_transaction():
         context.run_migrations()
 
-
 def run_migrations_online() -> None:
-    """Run migrations in 'online' mode.
+    """
+    Run migrations in 'online' mode.
 
     In this scenario we need to create an Engine
     and associate a connection with the context.
-
     """
 
     database = Database()
@@ -80,7 +77,6 @@ def run_migrations_online() -> None:
 
         with context.begin_transaction():
             context.run_migrations()
-
 
 if context.is_offline_mode():
     run_migrations_offline()

--- a/rechu/alembic/env.py
+++ b/rechu/alembic/env.py
@@ -9,10 +9,10 @@ database connectivity.
 from logging.config import fileConfig
 
 from alembic import context
+from alembic.util.exc import CommandError
 
 from rechu.database import Database
 from rechu.models import Base
-from rechu.settings import Settings
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
@@ -45,10 +45,12 @@ def run_migrations_offline() -> None:
     Calls to context.execute() here emit the given string to the script output.
     """
 
-    settings = Settings.get_settings()
-    url = settings.get("database", "uri")
+    database = Database()
+    if database.engine.name == 'sqlite':
+        raise CommandError('Offline mode currently not supported for SQLite')
+
     context.configure(
-        url=url,
+        url=database.engine.url,
         target_metadata=TARGET_METADATA,
         render_as_batch=True,
         literal_binds=True,

--- a/rechu/alembic/env.py
+++ b/rechu/alembic/env.py
@@ -1,0 +1,88 @@
+"""
+This is a Python script that is run whenever the alembic migration tool is
+invoked. It contains instructions to configure and generate a SQLAlchemy
+engine, procure a connection from that engine along with a transaction, and
+then invoke the migration engine, using the connection as a source of
+database connectivity.
+"""
+
+from logging.config import fileConfig
+
+from alembic import context
+
+from rechu.database import Database
+from rechu.models import Base
+from rechu.settings import Settings
+
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+config = context.config
+
+# Interpret the config file for Python logging.
+# This line sets up loggers basically.
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+# add your model's MetaData object here
+# for 'autogenerate' support
+# from myapp import mymodel
+# TARGET_METADATA = mymodel.Base.metadata
+TARGET_METADATA = Base.metadata
+
+# other values from the config, defined by the needs of env.py,
+# can be acquired:
+# my_important_option = config.get_main_option("my_important_option")
+# ... etc.
+
+
+def run_migrations_offline() -> None:
+    """Run migrations in 'offline' mode.
+
+    This configures the context with just a URL
+    and not an Engine, though an Engine is acceptable
+    here as well.  By skipping the Engine creation
+    we don't even need a DBAPI to be available.
+
+    Calls to context.execute() here emit the given string to the
+    script output.
+
+    """
+    settings = Settings.get_settings()
+    url = settings.get("database", "uri")
+    context.configure(
+        url=url,
+        target_metadata=TARGET_METADATA,
+        render_as_batch=True,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    """Run migrations in 'online' mode.
+
+    In this scenario we need to create an Engine
+    and associate a connection with the context.
+
+    """
+
+    database = Database()
+    connectable = database.engine
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection,
+            target_metadata=TARGET_METADATA,
+            render_as_batch=True
+        )
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/rechu/alembic/script.py.mako
+++ b/rechu/alembic/script.py.mako
@@ -1,0 +1,36 @@
+"""
+${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+"""
+# pylint: disable=invalid-name, line-too-long
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# Revision identifiers, used by Alembic.
+revision: str = ${repr(up_revision)}
+down_revision: Union[str, None] = ${repr(down_revision)}
+branch_labels: Union[str, Sequence[str], None] = ${repr(branch_labels)}
+depends_on: Union[str, Sequence[str], None] = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    """
+    Perform the upgrade.
+    """
+
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    """
+    Perform the downgrade.
+    """
+
+    ${downgrades if downgrades else "pass"}

--- a/rechu/alembic/versions/24c54f418b92_add_cascade_deletes_for_products_.py
+++ b/rechu/alembic/versions/24c54f418b92_add_cascade_deletes_for_products_.py
@@ -1,0 +1,62 @@
+"""
+Add cascade deletes for products/discounts
+
+Revision ID: 24c54f418b92
+Revises: 
+Create Date: 2025-02-07 23:15:46.360221
+"""
+# pylint: disable=invalid-name, line-too-long
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# Revision identifiers, used by Alembic.
+revision: str = '24c54f418b92'
+down_revision: Union[str, None] = None
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """
+    Perform the upgrade.
+    """
+
+    with op.batch_alter_table('receipt_discount', schema=None) as batch_op:
+        batch_op.drop_constraint('fk_receipt_discount_receipt_key_receipt', type_='foreignkey')
+        batch_op.create_foreign_key(batch_op.f('fk_receipt_discount_receipt_key_receipt'), 'receipt', ['receipt_key'], ['filename'], ondelete='CASCADE')
+
+    with op.batch_alter_table('receipt_discount_products', schema=None) as batch_op:
+        batch_op.drop_constraint('fk_receipt_discount_products_discount_id_receipt_discount', type_='foreignkey')
+        batch_op.drop_constraint('fk_receipt_discount_products_product_id_receipt_product', type_='foreignkey')
+        batch_op.create_foreign_key(batch_op.f('fk_receipt_discount_products_discount_id_receipt_discount'), 'receipt_discount', ['discount_id'], ['id'], ondelete='CASCADE')
+        batch_op.create_foreign_key(batch_op.f('fk_receipt_discount_products_product_id_receipt_product'), 'receipt_product', ['product_id'], ['id'], ondelete='CASCADE')
+
+    with op.batch_alter_table('receipt_product', schema=None) as batch_op:
+        batch_op.drop_constraint('fk_receipt_product_receipt_key_receipt', type_='foreignkey')
+        batch_op.create_foreign_key(batch_op.f('fk_receipt_product_receipt_key_receipt'), 'receipt', ['receipt_key'], ['filename'], ondelete='CASCADE')
+
+    # ### end Alembic commands ###
+
+
+def downgrade() -> None:
+    """
+    Perform the downgrade.
+    """
+
+    with op.batch_alter_table('receipt_product', schema=None) as batch_op:
+        batch_op.drop_constraint(batch_op.f('fk_receipt_product_receipt_key_receipt'), type_='foreignkey')
+        batch_op.create_foreign_key('fk_receipt_product_receipt_key_receipt', 'receipt', ['receipt_key'], ['filename'])
+
+    with op.batch_alter_table('receipt_discount_products', schema=None) as batch_op:
+        batch_op.drop_constraint(batch_op.f('fk_receipt_discount_products_product_id_receipt_product'), type_='foreignkey')
+        batch_op.drop_constraint(batch_op.f('fk_receipt_discount_products_discount_id_receipt_discount'), type_='foreignkey')
+        batch_op.create_foreign_key('fk_receipt_discount_products_product_id_receipt_product', 'receipt_product', ['product_id'], ['id'])
+        batch_op.create_foreign_key('fk_receipt_discount_products_discount_id_receipt_discount', 'receipt_discount', ['discount_id'], ['id'])
+
+    with op.batch_alter_table('receipt_discount', schema=None) as batch_op:
+        batch_op.drop_constraint(batch_op.f('fk_receipt_discount_receipt_key_receipt'), type_='foreignkey')
+        batch_op.create_foreign_key('fk_receipt_discount_receipt_key_receipt', 'receipt', ['receipt_key'], ['filename'])
+
+    # ### end Alembic commands ###

--- a/rechu/alembic/versions/24c54f418b92_add_cascade_deletes_for_products_.py
+++ b/rechu/alembic/versions/24c54f418b92_add_cascade_deletes_for_products_.py
@@ -11,9 +11,6 @@ from typing import Sequence, Union
 
 from alembic import op
 
-from rechu.database import Database
-from rechu.models.receipt import Discount, DiscountItems, ProductItem
-
 # Revision identifiers, used by Alembic.
 revision: str = '24c54f418b92'
 down_revision: Union[str, None] = None
@@ -25,9 +22,7 @@ def upgrade() -> None:
     Perform the upgrade.
     """
 
-    with op.batch_alter_table('receipt_discount',
-                              copy_from=Database.offline_table(Discount),
-                              schema=None) as batch_op:
+    with op.batch_alter_table('receipt_discount', schema=None) as batch_op:
         receipt_discount_key = 'fk_receipt_discount_receipt_key_receipt'
         batch_op.drop_constraint(receipt_discount_key, type_='foreignkey')
         batch_op.create_foreign_key(batch_op.f(receipt_discount_key), 'receipt',
@@ -35,7 +30,6 @@ def upgrade() -> None:
                                     ondelete='CASCADE')
 
     with op.batch_alter_table('receipt_discount_products',
-                              copy_from=Database.offline_table(DiscountItems),
                               schema=None) as batch_op:
         discount = 'fk_receipt_discount_products_discount_id_receipt_discount'
         product = 'fk_receipt_discount_products_product_id_receipt_product'
@@ -46,9 +40,7 @@ def upgrade() -> None:
         batch_op.create_foreign_key(batch_op.f(product), 'receipt_product',
                                     ['product_id'], ['id'], ondelete='CASCADE')
 
-    with op.batch_alter_table('receipt_product',
-                              copy_from=Database.offline_table(ProductItem),
-                              schema=None) as batch_op:
+    with op.batch_alter_table('receipt_product', schema=None) as batch_op:
         receipt_product_key = 'fk_receipt_product_receipt_key_receipt'
         batch_op.drop_constraint(receipt_product_key, type_='foreignkey')
         batch_op.create_foreign_key(batch_op.f(receipt_product_key), 'receipt',
@@ -63,9 +55,7 @@ def downgrade() -> None:
     Perform the downgrade.
     """
 
-    with op.batch_alter_table('receipt_product',
-                              copy_from=Database.offline_table(ProductItem),
-                              schema=None) as batch_op:
+    with op.batch_alter_table('receipt_product', schema=None) as batch_op:
         receipt_product_key = 'fk_receipt_product_receipt_key_receipt'
         batch_op.drop_constraint(batch_op.f(receipt_product_key),
                                  type_='foreignkey')
@@ -73,7 +63,6 @@ def downgrade() -> None:
                                     ['receipt_key'], ['filename'])
 
     with op.batch_alter_table('receipt_discount_products',
-                              copy_from=Database.offline_table(DiscountItems),
                               schema=None) as batch_op:
         product = 'fk_receipt_discount_products_product_id_receipt_product'
         discount = 'fk_receipt_discount_products_discount_id_receipt_discount'
@@ -84,9 +73,7 @@ def downgrade() -> None:
         batch_op.create_foreign_key(discount, 'receipt_discount',
                                     ['discount_id'], ['id'])
 
-    with op.batch_alter_table('receipt_discount',
-                              copy_from=Database.offline_table(Discount),
-                              schema=None) as batch_op:
+    with op.batch_alter_table('receipt_discount', schema=None) as batch_op:
         receipt_discount_key = 'fk_receipt_discount_receipt_key_receipt'
         batch_op.drop_constraint(batch_op.f(receipt_discount_key),
                                  type_='foreignkey')

--- a/rechu/alembic/versions/24c54f418b92_add_cascade_deletes_for_products_.py
+++ b/rechu/alembic/versions/24c54f418b92_add_cascade_deletes_for_products_.py
@@ -7,12 +7,11 @@ Create Date: 2025-02-07 23:15:46.360221
 """
 # pylint: disable=invalid-name
 
-from typing import Optional, Sequence, Union
+from typing import Sequence, Union
 
-from alembic import context, op
-from sqlalchemy import Table
+from alembic import op
 
-from rechu.models.base import Base
+from rechu.database import Database
 from rechu.models.receipt import Discount, DiscountItems, ProductItem
 
 # Revision identifiers, used by Alembic.
@@ -21,21 +20,13 @@ down_revision: Union[str, None] = None
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
-def _offline_table(model: Union[type[Base], Table]) -> Optional[Table]:
-    if context.is_offline_mode():
-        if isinstance(model, Table):
-            return model
-        if isinstance(model.__table__, Table):
-            return model.__table__
-    return None
-
 def upgrade() -> None:
     """
     Perform the upgrade.
     """
 
     with op.batch_alter_table('receipt_discount',
-                              copy_from=_offline_table(Discount),
+                              copy_from=Database.offline_table(Discount),
                               schema=None) as batch_op:
         receipt_discount_key = 'fk_receipt_discount_receipt_key_receipt'
         batch_op.drop_constraint(receipt_discount_key, type_='foreignkey')
@@ -44,7 +35,7 @@ def upgrade() -> None:
                                     ondelete='CASCADE')
 
     with op.batch_alter_table('receipt_discount_products',
-                              copy_from=_offline_table(DiscountItems),
+                              copy_from=Database.offline_table(DiscountItems),
                               schema=None) as batch_op:
         discount = 'fk_receipt_discount_products_discount_id_receipt_discount'
         product = 'fk_receipt_discount_products_product_id_receipt_product'
@@ -56,7 +47,7 @@ def upgrade() -> None:
                                     ['product_id'], ['id'], ondelete='CASCADE')
 
     with op.batch_alter_table('receipt_product',
-                              copy_from=_offline_table(ProductItem),
+                              copy_from=Database.offline_table(ProductItem),
                               schema=None) as batch_op:
         receipt_product_key = 'fk_receipt_product_receipt_key_receipt'
         batch_op.drop_constraint(receipt_product_key, type_='foreignkey')
@@ -73,7 +64,7 @@ def downgrade() -> None:
     """
 
     with op.batch_alter_table('receipt_product',
-                              copy_from=_offline_table(ProductItem),
+                              copy_from=Database.offline_table(ProductItem),
                               schema=None) as batch_op:
         receipt_product_key = 'fk_receipt_product_receipt_key_receipt'
         batch_op.drop_constraint(batch_op.f(receipt_product_key),
@@ -82,7 +73,7 @@ def downgrade() -> None:
                                     ['receipt_key'], ['filename'])
 
     with op.batch_alter_table('receipt_discount_products',
-                              copy_from=_offline_table(DiscountItems),
+                              copy_from=Database.offline_table(DiscountItems),
                               schema=None) as batch_op:
         product = 'fk_receipt_discount_products_product_id_receipt_product'
         discount = 'fk_receipt_discount_products_discount_id_receipt_discount'
@@ -94,7 +85,7 @@ def downgrade() -> None:
                                     ['discount_id'], ['id'])
 
     with op.batch_alter_table('receipt_discount',
-                              copy_from=_offline_table(Discount),
+                              copy_from=Database.offline_table(Discount),
                               schema=None) as batch_op:
         receipt_discount_key = 'fk_receipt_discount_receipt_key_receipt'
         batch_op.drop_constraint(batch_op.f(receipt_discount_key),

--- a/rechu/alembic/versions/9d5f6a8f4944_drop_foreign_key_for_receipt_shop.py
+++ b/rechu/alembic/versions/9d5f6a8f4944_drop_foreign_key_for_receipt_shop.py
@@ -1,0 +1,41 @@
+"""
+Drop foreign key for receipt shop
+
+Revision ID: 9d5f6a8f4944
+Revises: 24c54f418b92
+Create Date: 2025-02-10 20:23:02.768133
+"""
+# pylint: disable=invalid-name
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# Revision identifiers, used by Alembic.
+revision: str = '9d5f6a8f4944'
+down_revision: Union[str, None] = '24c54f418b92'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """
+    Perform the upgrade.
+    """
+
+    with op.batch_alter_table('receipt', schema=None) as batch_op:
+        batch_op.drop_constraint('fk_receipt_shop_shop', type_='foreignkey')
+
+    # ### end Alembic commands ###
+
+
+def downgrade() -> None:
+    """
+    Perform the downgrade.
+    """
+
+    with op.batch_alter_table('receipt', schema=None) as batch_op:
+        batch_op.create_foreign_key('fk_receipt_shop_shop', 'shop', ['shop'],
+                                    ['key'])
+
+    # ### end Alembic commands ###

--- a/rechu/command/__init__.py
+++ b/rechu/command/__init__.py
@@ -3,6 +3,7 @@ Subcommand collection package.
 """
 
 from .base import Base
+from .alembic import Alembic
 from .create import Create
 from .new import New
 from .read import Read

--- a/rechu/command/__init__.py
+++ b/rechu/command/__init__.py
@@ -5,6 +5,7 @@ Subcommand collection package.
 from .base import Base
 from .alembic import Alembic
 from .create import Create
+from .delete import Delete
 from .new import New
 from .read import Read
 

--- a/rechu/command/alembic.py
+++ b/rechu/command/alembic.py
@@ -2,7 +2,6 @@
 Subcommand to run Alembic commands for database migration.
 """
 
-import sys
 from alembic import config
 from .base import Base
 from ..database import Database
@@ -13,13 +12,31 @@ class Alembic(Base):
     Run an alembic command.
     """
 
+    subparser_keywords = {
+        # Let alembic handle `rechu alembic --help` argument
+        'add_help': False,
+        # Describe command in `rechu --help`
+        'help': 'Perform database revision management',
+        # Pass along all arguments to alembic even if they start with dashes
+        'prefix_chars': '\x00'
+    }
+    subparser_arguments = [
+        ('args', {'nargs': '*', 'help': 'alembic arguments'})
+    ]
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.args: list[str] = []
+
     def run(self) -> None:
         alembic_config = Database.get_alembic_config()
 
-        subcommand = sys.argv[2] if len(sys.argv) > 2 else ""
-        args = ["-c", str(alembic_config.config_file_name), subcommand]
+        subcommand = self.args[0] if self.args else ""
+        args = ["-c", str(alembic_config.config_file_name)]
+        if subcommand != "":
+            args.append(subcommand)
         if subcommand == "revision":
             args.append("--autogenerate")
-        args.extend(sys.argv[3:])
+        args.extend(self.args[1:])
 
-        config.main(argv=args, prog="rechu alembic")
+        config.main(argv=args, prog=f"{self.program} {self.subcommand}")

--- a/rechu/command/alembic.py
+++ b/rechu/command/alembic.py
@@ -1,0 +1,25 @@
+"""
+Subcommand to run Alembic commands for database migration.
+"""
+
+from pathlib import Path
+import sys
+from alembic import config
+from .base import Base
+
+@Base.register("alembic")
+class Alembic(Base):
+    """
+    Run an alembic command.
+    """
+
+    def run(self) -> None:
+        package_root = Path(__file__).resolve().parents[1]
+        alembic_config = package_root / 'alembic.ini'
+
+        subcommand = sys.argv[2] if len(sys.argv) > 2 else ""
+        args = sys.argv[3:]
+        if subcommand == "revision":
+            args.append("--autogenerate")
+
+        config.main(argv=["-c", str(alembic_config), subcommand] + args)

--- a/rechu/command/alembic.py
+++ b/rechu/command/alembic.py
@@ -2,10 +2,10 @@
 Subcommand to run Alembic commands for database migration.
 """
 
-from pathlib import Path
 import sys
 from alembic import config
 from .base import Base
+from ..database import Database
 
 @Base.register("alembic")
 class Alembic(Base):
@@ -14,12 +14,12 @@ class Alembic(Base):
     """
 
     def run(self) -> None:
-        package_root = Path(__file__).resolve().parents[1]
-        alembic_config = package_root / 'alembic.ini'
+        alembic_config = Database.get_alembic_config()
 
         subcommand = sys.argv[2] if len(sys.argv) > 2 else ""
-        args = sys.argv[3:]
+        args = ["-c", str(alembic_config.config_file_name), subcommand]
         if subcommand == "revision":
             args.append("--autogenerate")
+        args.extend(sys.argv[3:])
 
-        config.main(argv=["-c", str(alembic_config), subcommand] + args)
+        config.main(argv=args, prog="rechu alembic")

--- a/rechu/command/base.py
+++ b/rechu/command/base.py
@@ -2,15 +2,62 @@
 Base for receipt subcommands.
 """
 
-from typing import Callable
+from argparse import ArgumentParser, FileType, Namespace
+import os
+from pathlib import Path
+from typing import Callable, Iterable, Generic, Optional, Sequence, TypeVar, \
+    Union
+from typing_extensions import TypedDict
+from .. import __name__ as NAME, __version__ as VERSION
 from ..settings import Settings
 
-class Base:
+class SubparserKeywords(TypedDict, total=False):
+    """
+    Keyword arguments acceptable for subcommands to register to a subparser of
+    an argument parser.
+    """
+
+    help: Optional[str]
+    aliases: Sequence[str]
+    description: Optional[str]
+    epilog: Optional[str]
+    prefix_chars: str
+    fromfile_prefix_chars: Optional[str]
+    add_help: bool
+    allow_abbrev: bool
+
+ArgumentT = TypeVar('ArgumentT')
+
+class ArgumentKeywords(Generic[ArgumentT], TypedDict, total=False):
+    """
+    Keyword arguments acceptable for registering an argument to a subparser of
+    an argument parser.
+    """
+
+    action: str
+    nargs: Optional[Union[int, str]]
+    const: ArgumentT
+    default: Union[ArgumentT, str]
+    type: Union[Callable[[str], ArgumentT], FileType]
+    choices: Optional[Iterable[ArgumentT]]
+    required: bool
+    help: Optional[str]
+    metavar: Optional[Union[str, tuple[str, ...]]]
+    dest: Optional[str]
+
+ArgumentSpec = tuple[Union[str, tuple[str, ...]], ArgumentKeywords]
+SubparserArguments = Iterable[ArgumentSpec]
+
+class Base(Namespace):
     """
     Abstract command handling.
     """
 
     _commands: dict[str, type['Base']] = {}
+    program: str = NAME
+    subcommand: str = ''
+    subparser_keywords: SubparserKeywords = {}
+    subparser_arguments: SubparserArguments = []
 
     @classmethod
     def register(cls, name: str) -> Callable[[type['Base']], type['Base']]:
@@ -20,6 +67,7 @@ class Base:
 
         def decorator(subclass: type['Base']) -> type['Base']:
             cls._commands[name] = subclass
+            subclass.subcommand = name
             return subclass
 
         return decorator
@@ -32,7 +80,57 @@ class Base:
 
         return cls._commands[name]()
 
+    @classmethod
+    def register_arguments(cls) -> ArgumentParser:
+        """
+        Create an argument parser for all registered subcommands.
+        """
+
+        parser = ArgumentParser(prog=cls.program,
+                                description='Receipt cataloging hub')
+        parser.add_argument('--version', action='version',
+                            version=f'{NAME} {VERSION}')
+        subparsers = parser.add_subparsers(dest='subcommand',
+                                           help='Subcommands')
+        for name, subclass in cls._commands.items():
+            subparser = subparsers.add_parser(name,
+                                              **subclass.subparser_keywords)
+            for (argument, keywords) in subclass.subparser_arguments:
+                if isinstance(argument, str):
+                    subparser.add_argument(argument, **keywords)
+                else:
+                    subparser.add_argument(*argument, **keywords)
+
+        return parser
+
+    @classmethod
+    def start(cls, executable: str, argv: Sequence[str]) -> None:
+        """
+        Parse arguments from a sequence of command line arguments and determine
+        which command to run, register any arguments to it and finally execute
+        the action of the command.
+        """
+
+        cls.program = Path(argv[0]).name
+        if cls.program == "__main__.py":
+            python = Path(executable)
+            if str(python.parent) in os.get_exec_path():
+                executable = python.name
+            cls.program = f"{executable} -m {NAME}"
+
+        parser = cls.register_arguments()
+        if len(argv) <= 1:
+            parser.print_usage()
+            return
+
+        parser.parse_known_args(argv[1:], namespace=cls)
+        command = cls.get_command(cls.subcommand)
+        command.program = cls.program
+        parser.parse_args(argv[1:], namespace=command)
+        command.run()
+
     def __init__(self) -> None:
+        super().__init__()
         self.settings = Settings.get_settings()
 
     def run(self) -> None:

--- a/rechu/command/create.py
+++ b/rechu/command/create.py
@@ -11,6 +11,11 @@ class Create(Base):
     Create the database with the database schema.
     """
 
+    subparser_keywords = {
+        'help': 'Create the database and schema',
+        'description': 'Create database schema tables at the configured URI.'
+    }
+
     def run(self) -> None:
         database = Database()
         database.create_schema()

--- a/rechu/command/create.py
+++ b/rechu/command/create.py
@@ -4,7 +4,6 @@ Database schema creation subcommand.
 
 from .base import Base
 from ..database import Database
-from ..models.base import Base as ModelBase
 
 @Base.register("create")
 class Create(Base):
@@ -13,5 +12,5 @@ class Create(Base):
     """
 
     def run(self) -> None:
-        with Database() as session:
-            ModelBase.metadata.create_all(session.get_bind())
+        database = Database()
+        database.create_schema()

--- a/rechu/command/delete.py
+++ b/rechu/command/delete.py
@@ -1,0 +1,57 @@
+"""
+Subcommand to remove receipt YAML file(s) from data path and database.
+"""
+
+import logging
+from pathlib import Path
+from sqlalchemy import delete
+from .base import Base
+from ..database import Database
+from ..models import Receipt
+
+@Base.register("delete")
+class Delete(Base):
+    """
+    Delete YAML files and database entries for receipts.
+    """
+
+    subparser_keywords = {
+        'aliases': ['rm'],
+        'help': 'Delete receipt files and/or database entries',
+        'description': 'Delete YAML files for receipts from the data paths and '
+                       'from the database.'
+    }
+    subparser_arguments = [
+        ('files', {
+            'metavar': 'FILE',
+            'nargs': '+',
+            'help': 'One or more files to delete'
+        }),
+        (('-k', '--keep'), {
+            'action': 'store_true',
+            'default': False,
+            'help': 'Do not delete YAML file from data path'
+        })
+    ]
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.files: list[str] = []
+        self.keep = False
+
+    def run(self) -> None:
+        data_path = Path(self.settings.get('data', 'path'))
+        data_pattern = self.settings.get('data', 'pattern')
+
+        # Filter off path elements to just keep the file name
+        files = tuple(Path(file).name for file in self.files)
+
+        with Database() as session:
+            session.execute(delete(Receipt).where(Receipt.filename.in_(files)))
+
+        if not self.keep:
+            for file in files:
+                try:
+                    next(data_path.glob(f"{data_pattern}/{file}")).unlink()
+                except (StopIteration, FileNotFoundError):
+                    logging.warning("File not found in data path: %s", file)

--- a/rechu/command/new.py
+++ b/rechu/command/new.py
@@ -29,6 +29,12 @@ class New(Base):
     Create a YAML file for a receipt and import it to the database.
     """
 
+    subparser_keywords = {
+        'help': 'Create receipt file and import',
+        'description': 'Interactively fill in a YAML file for a receipt and '
+                       'import it to the database.'
+    }
+
     def __init__(self) -> None:
         super().__init__()
         self.suggestions: dict[str, list[str]] = {}

--- a/rechu/command/read.py
+++ b/rechu/command/read.py
@@ -26,6 +26,12 @@ class Read(Base):
     Read updated YAML files and import them to the database.
     """
 
+    subparser_keywords = {
+        'help': 'Import updated receipt files to the database',
+        'description': 'Find YAML files for receipts from the data paths and '
+                       'import new or updated files to the database.'
+    }
+
     def run(self) -> None:
         data_path = Path(self.settings.get('data', 'path'))
         data_pattern = self.settings.get('data', 'pattern')

--- a/rechu/database.py
+++ b/rechu/database.py
@@ -5,10 +5,10 @@ Database access.
 from pathlib import Path
 import sys
 from types import TracebackType
-from typing import Optional, TextIO
+from typing import Optional, TextIO, Union
 from alembic.config import Config
-from alembic import command
-from sqlalchemy import create_engine
+from alembic import command, context
+from sqlalchemy import create_engine, Table
 from sqlalchemy.orm import Session
 from .models.base import Base
 from .settings import Settings
@@ -50,6 +50,26 @@ class Database:
 
         package_root = Path(__file__).resolve().parent
         return Config(package_root / 'alembic.ini', stdout=stdout)
+
+    @staticmethod
+    def offline_table(model: Union[type[Base], Table]) -> Optional[Table]:
+        """
+        Retrieve an SQLAlchemy Table reference object when running an alembic
+        migration in offline (SQL generation) mode. Under SQLite, we often need
+        to perform a "move and copy" migration; in online mode, SQLAlchemy can
+        perform reflection to deduce what to do, but when using offline mode,
+        the entire table needs to be provided from the model. To avoid overhead
+        in online migrations, we skip providing the table from model, so only
+        during offline migrations will we provide the table.
+        """
+
+        if not context.is_offline_mode():
+            return None
+        if isinstance(model, Table):
+            return model
+        if hasattr(model, '__table__') and isinstance(model.__table__, Table):
+            return model.__table__
+        return None
 
     def __del__(self) -> None:
         self.close()

--- a/rechu/models/receipt.py
+++ b/rechu/models/receipt.py
@@ -19,11 +19,12 @@ class Receipt(Base): # pylint: disable=too-few-public-methods
     filename: Mapped[str] = mapped_column(String(255), primary_key=True)
     updated: Mapped[datetime.datetime]
     date: Mapped[datetime.date]
-    shop: Mapped[str] = mapped_column(ForeignKey("shop.key"))
+    shop: Mapped[str] = mapped_column(String(32)) # shop.key
     products: Mapped[list["ProductItem"]] = \
-        relationship(back_populates="receipt", cascade="all, delete-orphan")
+        relationship(back_populates="receipt", cascade="all, delete-orphan",
+                     passive_deletes=True)
     discounts: Mapped[list["Discount"]] = \
-        relationship(cascade="all, delete-orphan")
+        relationship(cascade="all, delete-orphan", passive_deletes=True)
 
 # Association table for products involved in discounts
 DiscountItems = Table("receipt_discount_products", Base.metadata,
@@ -51,7 +52,8 @@ class ProductItem(Base): # pylint: disable=too-few-public-methods
     price: Mapped[Price]
     discount_indicator: Mapped[Optional[str]]
     discounts: Mapped[list["Discount"]] = \
-        relationship(secondary=DiscountItems, back_populates="items")
+        relationship(secondary=DiscountItems, back_populates="items",
+                     passive_deletes=True)
 
 class Discount(Base): # pylint: disable=too-few-public-methods
     """
@@ -68,4 +70,5 @@ class Discount(Base): # pylint: disable=too-few-public-methods
     label: Mapped[str]
     price_decrease: Mapped[Price]
     items: Mapped[list[ProductItem]] = \
-        relationship(secondary=DiscountItems, back_populates="discounts")
+        relationship(secondary=DiscountItems, back_populates="discounts",
+                     passive_deletes=True)

--- a/rechu/models/receipt.py
+++ b/rechu/models/receipt.py
@@ -27,9 +27,11 @@ class Receipt(Base): # pylint: disable=too-few-public-methods
 
 # Association table for products involved in discounts
 DiscountItems = Table("receipt_discount_products", Base.metadata,
-                      Column("discount_id", ForeignKey('receipt_discount.id'),
+                      Column("discount_id", ForeignKey('receipt_discount.id',
+                                                       ondelete='CASCADE'),
                              primary_key=True),
-                      Column("product_id", ForeignKey('receipt_product.id'),
+                      Column("product_id", ForeignKey('receipt_product.id',
+                                                      ondelete='CASCADE'),
                              primary_key=True))
 
 class ProductItem(Base): # pylint: disable=too-few-public-methods
@@ -40,7 +42,8 @@ class ProductItem(Base): # pylint: disable=too-few-public-methods
     __tablename__ = "receipt_product"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    receipt_key: Mapped[str] = mapped_column(ForeignKey('receipt.filename'))
+    receipt_key: Mapped[str] = mapped_column(ForeignKey('receipt.filename',
+                                                        ondelete='CASCADE'))
     receipt: Mapped[Receipt] = relationship(back_populates="products")
 
     quantity: Mapped[str]
@@ -58,7 +61,8 @@ class Discount(Base): # pylint: disable=too-few-public-methods
     __tablename__ = "receipt_discount"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    receipt_key: Mapped[str] = mapped_column(ForeignKey('receipt.filename'))
+    receipt_key: Mapped[str] = mapped_column(ForeignKey('receipt.filename',
+                                                        ondelete='CASCADE'))
     receipt: Mapped[Receipt] = relationship(back_populates="discounts")
 
     label: Mapped[str]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
+alembic==1.14.1
 python-dateutil==2.9.0.post0
 PyYAML==6.0.2
 SQLAlchemy==2.0.36
 tomlkit==0.13.2
+typing_extensions==4.12.2

--- a/settings.toml.example
+++ b/settings.toml.example
@@ -12,5 +12,5 @@ uri = "sqlite+pysqlite:///example.db"
 # Whether to use foreign keys on SQLite. Current versions of the models require
 # this to correctly delete dependent entities, but it could be disabled when
 # using older models where this support was not properly usable (and some models
-# would break with foreign keys enabled).
+# would break with foreign keys enabled). To disable, set to "OFF".
 foreign_keys = "ON"

--- a/settings.toml.example
+++ b/settings.toml.example
@@ -1,7 +1,16 @@
 [data]
+# Relative or absolute path to the YAML data directory.
 path = "."
+# Subdirectory glob pattern to detect additional paths within the data path.
 pattern = "."
+# Filename format for YAML receipt files generated with `rechu new`.
 format = "{date:%Y}-{date:%m}-{date:%d}-{date:%H}-{date:%M}-{shop}.yml"
 
 [database]
+# The SQLAlchemy connection URI to connect to the database.
 uri = "sqlite+pysqlite:///example.db"
+# Whether to use foreign keys on SQLite. Current versions of the models require
+# this to correctly delete dependent entities, but it could be disabled when
+# using older models where this support was not properly usable (and some models
+# would break with foreign keys enabled).
+foreign_keys = "ON"

--- a/settings.toml.test
+++ b/settings.toml.test
@@ -5,3 +5,4 @@ format = "samples/{date:%Y}-{date:%m}-{date:%d}-{date:%H}-{date:%M}-{shop}.yml"
 
 [database]
 uri = "sqlite+pysqlite:///test.db"
+foreign_keys = "ON"

--- a/tests/command/alembic.py
+++ b/tests/command/alembic.py
@@ -2,10 +2,12 @@
 Tests of subcommand to run Alembic commands for database migration.
 """
 
+from io import StringIO
 from pathlib import Path
 import unittest
 from unittest.mock import MagicMock, patch
 from rechu.command.alembic import Alembic
+from rechu.database import Database
 
 class AlembicTest(unittest.TestCase):
     """
@@ -34,3 +36,22 @@ class AlembicTest(unittest.TestCase):
                                                       "--autogenerate",
                                                       "-m", "a"],
                                                 prog="rechu alembic")
+
+    def test_downgrade_upgrade(self) -> None:
+        """
+        Test downgrading and upgrading the database.
+        """
+
+        database = Database()
+        database.create_schema()
+
+        alembic = Alembic()
+        with patch("sys.argv", new=["rechu", "alembic", "downgrade", "base"]):
+            alembic.run()
+        with patch("sys.argv",
+                   new=["rechu", "alembic", "upgrade", "--sql", "head"]):
+            with patch("sys.stdout", new_callable=StringIO) as stdout:
+                alembic.run()
+                self.assertNotEqual(stdout.getvalue(), '')
+        with patch("sys.argv", new=["rechu", "alembic", "upgrade", "head"]):
+            alembic.run()

--- a/tests/command/alembic.py
+++ b/tests/command/alembic.py
@@ -1,0 +1,36 @@
+"""
+Tests of subcommand to run Alembic commands for database migration.
+"""
+
+from pathlib import Path
+import unittest
+from unittest.mock import MagicMock, patch
+from rechu.command.alembic import Alembic
+
+class AlembicTest(unittest.TestCase):
+    """
+    Test running an alembic command.
+    """
+
+    @patch("rechu.command.alembic.config")
+    def test_run(self, config: MagicMock) -> None:
+        """
+        Test executing the command.
+        """
+
+        alembic = Alembic()
+        path = Path("rechu/alembic.ini").resolve()
+        with patch("sys.argv", new=["rechu", "alembic"]):
+            alembic.run()
+            config.main.assert_called_once_with(argv=["-c", str(path), ""],
+                                                prog="rechu alembic")
+
+        config.main.reset_mock()
+
+        with patch("sys.argv", new=["rechu", "alembic", "revision", "-m", "a"]):
+            alembic.run()
+            config.main.assert_called_once_with(argv=["-c", str(path),
+                                                      "revision",
+                                                      "--autogenerate",
+                                                      "-m", "a"],
+                                                prog="rechu alembic")

--- a/tests/command/alembic.py
+++ b/tests/command/alembic.py
@@ -20,22 +20,27 @@ class AlembicTest(unittest.TestCase):
         Test executing the command.
         """
 
+        path = str(Path("rechu/alembic.ini").resolve())
+
         alembic = Alembic()
-        path = Path("rechu/alembic.ini").resolve()
-        with patch("sys.argv", new=["rechu", "alembic"]):
-            alembic.run()
-            config.main.assert_called_once_with(argv=["-c", str(path), ""],
-                                                prog="rechu alembic")
+        alembic.run()
+        config.main.assert_called_once_with(argv=["-c", path],
+                                            prog="rechu alembic")
 
         config.main.reset_mock()
 
-        with patch("sys.argv", new=["rechu", "alembic", "revision", "-m", "a"]):
-            alembic.run()
-            config.main.assert_called_once_with(argv=["-c", str(path),
-                                                      "revision",
-                                                      "--autogenerate",
-                                                      "-m", "a"],
-                                                prog="rechu alembic")
+        alembic.args = ["-h"]
+        alembic.run()
+        config.main.assert_called_once_with(argv=["-c", path, "-h"],
+                                            prog="rechu alembic")
+
+        config.main.reset_mock()
+
+        alembic.args = ["revision", "-m", "a"]
+        alembic.run()
+        config.main.assert_called_once_with(argv=["-c", path, "revision",
+                                                  "--autogenerate", "-m", "a"],
+                                            prog="rechu alembic")
 
     def test_downgrade_upgrade(self) -> None:
         """
@@ -46,12 +51,13 @@ class AlembicTest(unittest.TestCase):
         database.create_schema()
 
         alembic = Alembic()
-        with patch("sys.argv", new=["rechu", "alembic", "downgrade", "base"]):
+        alembic.args = ["downgrade", "base"]
+        alembic.run()
+
+        alembic.args = ["upgrade", "--sql", "head"]
+        with patch("sys.stdout", new_callable=StringIO) as stdout:
             alembic.run()
-        with patch("sys.argv",
-                   new=["rechu", "alembic", "upgrade", "--sql", "head"]):
-            with patch("sys.stdout", new_callable=StringIO) as stdout:
-                alembic.run()
-                self.assertNotEqual(stdout.getvalue(), '')
-        with patch("sys.argv", new=["rechu", "alembic", "upgrade", "head"]):
-            alembic.run()
+            self.assertNotEqual(stdout.getvalue(), '')
+
+        alembic.args = ["upgrade", "head"]
+        alembic.run()

--- a/tests/command/base.py
+++ b/tests/command/base.py
@@ -2,6 +2,12 @@
 Tests for receipt subcommand base.
 """
 
+from argparse import ArgumentParser
+import os
+from pathlib import Path
+from typing import Optional
+from unittest.mock import DEFAULT, MagicMock, call, patch
+from rechu import __version__ as VERSION
 from rechu.command.base import Base
 from ..settings import SettingsTestCase
 
@@ -11,8 +17,17 @@ class TestCommand(Base):
     Example subcommand.
     """
 
+    latest_object: Optional['TestCommand'] = None
+    subparser_keywords = {'help': 'Test command'}
+    subparser_arguments = [
+        ('fool', {'type': int, 'help': 'ABC'}),
+        (('-b', '--bar'), {'dest': 'bizarre'})
+    ]
+    fool: int
+    bizarre: str
+
     def run(self) -> None:
-        pass
+        self.__class__.latest_object = self
 
 class BaseTest(SettingsTestCase):
     """
@@ -26,6 +41,54 @@ class BaseTest(SettingsTestCase):
 
         test = Base.get_command("test")
         self.assertIsInstance(test, TestCommand)
+
+    @patch("rechu.command.base.ArgumentParser")
+    def test_register_arguments(self, parser: MagicMock) -> None:
+        """
+        Test creating an argument parser for all registered subcommands.
+        """
+
+        Base.register_arguments()
+        parser.assert_called_once_with(prog='rechu',
+                                       description='Receipt cataloging hub')
+        main = parser.return_value
+        main.add_argument.assert_called_once_with('--version', action='version',
+                                                  version=f'rechu {VERSION}')
+        main.add_subparsers.assert_called_once_with(dest='subcommand',
+                                                    help='Subcommands')
+        subparsers = main.add_subparsers.return_value
+        subparsers.add_parser.assert_called_with('test', help='Test command')
+        subparser = subparsers.add_parser.return_value
+        subparser.add_argument.assert_has_calls([
+            call('fool', type=int, help='ABC'),
+            call('-b', '--bar', dest='bizarre')
+        ])
+
+    @patch.multiple(ArgumentParser, print_usage=DEFAULT, print_help=DEFAULT,
+                    exit=DEFAULT)
+    def test_start(self, **mocks: MagicMock) -> None:
+        """
+        Test parsing command line arguments, registering them to a command and
+        executing the action of the command.
+        """
+
+        Base.start("python", ["env/bin/rechu"])
+        self.assertEqual(Base.program, "rechu")
+        mocks['print_usage'].assert_called_once_with()
+
+        Base.start(str(Path(os.get_exec_path()[0], "python")),
+                   ["rechu/__main__.py", "test", "--help"])
+        self.assertEqual(Base.program, "python -m rechu")
+        mocks['print_help'].assert_called()
+        mocks['exit'].assert_called()
+
+        Base.start("env/bin/python",
+                   ["rechu/__main__.py", "test", "1234", "-b", "qux"])
+        self.assertEqual(Base.program, "env/bin/python -m rechu")
+        if TestCommand.latest_object is None:
+            self.fail("Unexpected missing latest command object")
+        self.assertEqual(TestCommand.latest_object.fool, 1234)
+        self.assertEqual(TestCommand.latest_object.bizarre, "qux")
 
     def test_run(self) -> None:
         """

--- a/tests/command/delete.py
+++ b/tests/command/delete.py
@@ -1,0 +1,63 @@
+"""
+Tests of subcommand to remove receipt YAML files and database entries.
+"""
+
+from pathlib import Path
+from sqlalchemy import select
+from rechu.command.delete import Delete
+from rechu.io.receipt import ReceiptReader
+from rechu.models.receipt import Receipt, DiscountItems, ProductItem, Discount
+from ..database import DatabaseTestCase
+
+class DeleteTest(DatabaseTestCase):
+    """
+    Test deleting YAML files and database entries for receipts.
+    """
+
+    copies = [Path("samples/receipt-1.yml"), Path("samples/receipt-2.yml")]
+
+    def tearDown(self) -> None:
+        super().tearDown()
+        for copy in self.copies:
+            copy.unlink(missing_ok=True)
+
+    def test_run(self) -> None:
+        """
+        Test executing the command.
+        """
+
+        path = Path("samples/receipt.yml").resolve()
+
+        with self.database as session:
+            session.add(next(ReceiptReader(path).read()))
+
+        command = Delete()
+        command.files = [str(path)]
+        command.keep = True
+        command.run()
+
+        with self.database as session:
+            self.assertIsNone(session.scalars(select(Receipt)).first())
+            self.assertIsNone(session.scalars(select(ProductItem)).first())
+            self.assertIsNone(session.scalars(select(Discount)).first())
+            self.assertIsNone(session.scalars(select(DiscountItems)).first())
+
+        with self.database as session:
+            session.add(next(ReceiptReader(path).read()))
+            for copy in self.copies:
+                copy.symlink_to(path.name)
+                self.assertEqual(copy.resolve(), path)
+                session.add(next(ReceiptReader(copy).read()))
+
+        command.files = ["receipt-1.yml", "receipt-2.yml", "missing.yml"]
+        command.keep = False
+        command.run()
+
+        with self.database as session:
+            receipts = list(session.scalars(select(Receipt)))
+            self.assertEqual(len(receipts), 1)
+            self.assertEqual(receipts[0].filename, 'receipt.yml')
+
+        self.assertTrue(path.exists())
+        for copy in self.copies:
+            self.assertFalse(copy.exists())

--- a/tests/command/read.py
+++ b/tests/command/read.py
@@ -6,26 +6,18 @@ from datetime import datetime
 import os
 from sqlalchemy import select
 from rechu.command.read import Read
-from rechu.database import Database
-from rechu.models import Base, Receipt
-from ..settings import SettingsTestCase
+from rechu.models import Receipt
+from ..database import DatabaseTestCase
 
-class ReadTest(SettingsTestCase):
+class ReadTest(DatabaseTestCase):
     """
     Test reading the YAML files and importing them to the database.
     """
-
-    def tearDown(self) -> None:
-        with Database() as session:
-            Base.metadata.drop_all(session.get_bind())
 
     def test_run(self) -> None:
         """
         Test executing the command.
         """
-
-        with Database() as session:
-            Base.metadata.create_all(session.get_bind())
 
         now = datetime.now().timestamp()
         os.utime('samples', times=(now, now))
@@ -34,7 +26,7 @@ class ReadTest(SettingsTestCase):
         command = Read()
         command.run()
 
-        with Database() as session:
+        with self.database as session:
             receipt = session.scalars(select(Receipt)).first()
             if receipt is None:
                 self.fail("Expected receipt to be stored")
@@ -44,7 +36,7 @@ class ReadTest(SettingsTestCase):
         # Nothing happens if the directory is not updated.
         command.run()
 
-        with Database() as session:
+        with self.database as session:
             receipt = session.scalars(select(Receipt)).first()
             if receipt is None:
                 self.fail("Expected receipt to be stored")
@@ -56,7 +48,7 @@ class ReadTest(SettingsTestCase):
         # Nothing happens if the file is not updated.
         command.run()
 
-        with Database() as session:
+        with self.database as session:
             receipt = session.scalars(select(Receipt)).first()
             if receipt is None:
                 self.fail("Expected receipt to be stored")
@@ -66,7 +58,7 @@ class ReadTest(SettingsTestCase):
         os.utime('samples/receipt.yml', times=(now + 1, now + 1))
         command.run()
 
-        with Database() as session:
+        with self.database as session:
             receipt = session.scalars(select(Receipt)).first()
             if receipt is None:
                 self.fail("Expected receipt to be stored")

--- a/tests/database.py
+++ b/tests/database.py
@@ -2,17 +2,33 @@
 Tests for database access.
 """
 
+from io import StringIO
+from pathlib import Path
+from alembic import command
+from sqlalchemy import select
+from sqlalchemy.exc import OperationalError
 from rechu.database import Database
+from rechu.models import Receipt
 from .settings import SettingsTestCase
 
-class DatabaseTest(SettingsTestCase):
+class DatabaseTestCase(SettingsTestCase):
     """
-    Tests for database provider.
+    Test case base class which creates and drops the database between tests.
     """
 
     def setUp(self) -> None:
         super().setUp()
         self.database = Database()
+        self.database.create_schema()
+
+    def tearDown(self) -> None:
+        super().tearDown()
+        self.database.drop_schema()
+
+class DatabaseTest(DatabaseTestCase):
+    """
+    Tests for database provider.
+    """
 
     def test_enter(self) -> None:
         """
@@ -40,3 +56,38 @@ class DatabaseTest(SettingsTestCase):
             self.assertEqual(session, self.database.session)
             self.database.close()
             self.assertIsNone(self.database.session)
+
+    def test_create_schema(self) -> None:
+        """
+        Test performing schema creation.
+        """
+
+        # First ensure the database is empty.
+        self.database.drop_schema()
+
+        self.database.create_schema()
+        # Check if a model's table is empty but existing.
+        with self.database as session:
+            self.assertEqual(list(session.scalars(select(Receipt))), [])
+        # Check alembic stamped version.
+        stdout = StringIO()
+        command.current(self.database.get_alembic_config(stdout=stdout))
+        self.assertIn("head", stdout.getvalue())
+
+    def test_drop_schema(self) -> None:
+        """
+        Test cleaning up the database by removing all model tables.
+        """
+
+        self.database.drop_schema()
+        with self.assertRaisesRegex(OperationalError, "no such table: receipt"):
+            with self.database as session:
+                self.assertNotEqual(list(session.scalars(select(Receipt))), [])
+
+    def test_get_alembic_config(self) -> None:
+        """
+        Test retrieving an alembic configuration object preconfigured for rechu.
+        """
+
+        self.assertEqual(self.database.get_alembic_config().config_file_name,
+                         Path("rechu/alembic.ini").resolve())

--- a/tests/database.py
+++ b/tests/database.py
@@ -4,13 +4,11 @@ Tests for database access.
 
 from io import StringIO
 from pathlib import Path
-from unittest.mock import MagicMock, patch
 from alembic import command
-from sqlalchemy import select, Table
+from sqlalchemy import select
 from sqlalchemy.exc import OperationalError
 from rechu.database import Database
-from rechu.models.base import Base
-from rechu.models.receipt import Receipt, DiscountItems
+from rechu.models.receipt import Receipt
 from .settings import SettingsTestCase
 
 class DatabaseTestCase(SettingsTestCase):
@@ -93,21 +91,3 @@ class DatabaseTest(DatabaseTestCase):
 
         self.assertEqual(self.database.get_alembic_config().config_file_name,
                          Path("rechu/alembic.ini").resolve())
-
-    @patch("rechu.database.context")
-    def test_offline_table(self, context: MagicMock) -> None:
-        """
-        Test retrieving a table reerence when running alembic migration in
-        offline mode.
-        """
-
-        mock_keywords: dict[str, bool] = {'is_offline_mode.return_value': False}
-        context.configure_mock(**mock_keywords)
-        self.assertIsNone(Database.offline_table(Receipt))
-
-        mock_keywords = {'is_offline_mode.return_value': True}
-        context.configure_mock(**mock_keywords)
-        self.assertIsInstance(Database.offline_table(Receipt), Table)
-        self.assertIsInstance(Database.offline_table(DiscountItems), Table)
-
-        self.assertIsNone(Database.offline_table(Base))


### PR DESCRIPTION
- Alembic environment setup for migration management (online migrations only for SQLite), with subcommand integrated into rechu
- Add migration for product items, discounts and discounted products to perform cascade-deletion if a (parent) receipt/discount is deleted
- Add migration to drop foreign key for receipt shop key
- Enable foreign key constraints on SQLite
- Command interface now has help system and argument passing to subcommands
- Add delete subcommand to remove receipt YAML file and entries in database