### PR TITLE
Settings: Add fallback to default settings

### DIFF
--- a/schema/settings.json
+++ b/schema/settings.json
@@ -1,0 +1,63 @@
+{
+    "$id": "https://lhelwerd.github.io/rechu/schema/settings.json",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "Receipt cataloging hub settings",
+    "$ref": "#/$defs/settings",
+    "$defs": {
+        "settings": {
+            "type": "object",
+            "properties": {
+                "data": {"$ref": "#/$defs/data"},
+                "database": {"$ref": "#/$defs/database"}
+            },
+            "patternProperties": {
+                "^.+$": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^.+$": {"type": "string"}
+                    }
+                }
+            },
+            "unevaluatedProperties": false
+        },
+        "data": {
+            "description": "Filesystem data IO settings.",
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Relative or absolute path to the YAML data directory.",
+                    "default": "."
+                },
+                "pattern": {
+                    "type": "string",
+                    "description": "Subdirectory glob pattern to detect additional paths within the data path.",
+                    "default": "."
+                },
+                "format": {
+                    "type": "string",
+                    "description": "Filename format for YAML receipt files generated with `rechu new`.",
+                    "default": "{date:%Y}-{date:%m}-{date:%d}-{date:%H}-{date:%M}-{shop}.yml"
+                }
+            }
+        },
+        "database": {
+            "description": "Database connection settings.",
+            "type": "object",
+            "properties": {
+                "uri": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "The SQLAlchemy connection URI to connect to the database.",
+                    "default": "sqlite+pysqlite:///example.db"
+                },
+                "foreign_keys": {
+                    "type": "string",
+                    "enum": ["ON", "OFF", "on", "off"],
+                    "description": "Whether to use foreign keys on SQLite. Current versions of the models require this to correctly delete dependent entities, but it could be disabled when using older models where this support was not properly usable (and some models would break with foreign keys enabled). To disable, set to \"OFF\".",
+                    "default": "ON"
+                }
+            }
+        }
+    }
+}

--- a/scripts/validate_schema.sh
+++ b/scripts/validate_schema.sh
@@ -25,6 +25,12 @@ fi
 echo "Validating schemas in $ROOT_DIR/schema against metaschema"
 check-jsonschema --check-metaschema $ROOT_DIR/schema/*.json
 
+echo "Validating settings.toml, settings.toml.example and settings.toml.test"
+if [ -f "$ROOT_DIR/settings.toml" ]; then
+	check-jsonschema --schemafile $ROOT_DIR/schema/settings.json $ROOT_DIR/settings.toml
+fi
+check-jsonschema --schemafile $ROOT_DIR/schema/settings.json --default-filetype toml $ROOT_DIR/settings.toml.{example,test}
+
 echo "Validating $DATA_DIR/products.yml"
 check-jsonschema --schemafile $ROOT_DIR/schema/products.json $DATA_DIR/products.yml
 

--- a/settings.toml.test
+++ b/settings.toml.test
@@ -5,4 +5,4 @@ format = "samples/{date:%Y}-{date:%m}-{date:%d}-{date:%H}-{date:%M}-{shop}.yml"
 
 [database]
 uri = "sqlite+pysqlite:///test.db"
-foreign_keys = "ON"
+#foreign_keys = "ON" # Retrieved from defaults

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -58,3 +58,22 @@ class SettingsTest(SettingsTestCase):
         with self.assertRaisesRegex(KeyError,
                                     'data is not a section or does not have ?'):
             settings.get('data', '?')
+
+        # Defaults
+        self.assertEqual(settings.get('database', 'foreign_keys'), 'ON')
+
+    def test_get_missing(self) -> None:
+        """
+        Test retrieving a settings item with a missing settings file.
+        """
+
+        environ = {
+            'RECHU_SETTINGS_FILE': 'samples/settings.toml.missing',
+            'RECHU_DATA_PATH': '/tmp'
+        }
+        with patch.dict('os.environ', environ):
+            settings = Settings.get_settings()
+            self.assertEqual(settings.get('data', 'path'), '/tmp')
+            self.assertEqual(settings.get('data', 'pattern'), '.')
+            with self.assertRaises(KeyError):
+                settings.get('missing', 'path')


### PR DESCRIPTION
If settings file is missing or certain entries are not available, then use the example file as fallback (lazy-load the file).

Add schema for settings file and validate the settings files.