### PR TITLE
Run with pytest, provide reports to SonarCloud

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -21,10 +21,12 @@ jobs:
           make setup
           make setup_test
       - name: Unit test and coverage
+        id: coverage
+        continue-on-error: true
         run: |
-          make coverage
+          TEST_NAME=sqlite-${{ matrix.python }} make -i coverage
           pip install psycopg2==2.9.10
-          RECHU_DATABASE_URI=postgresql+psycopg2://postgres:test@localhost:5432/postgres make coverage
+          TEST_NAME=postgresql-${{ matrix.python }} RECHU_DATABASE_URI=postgresql+psycopg2://postgres:test@localhost:5432/postgres make coverage
       - name: Coveralls upload
         run: |
           pip install coveralls
@@ -32,8 +34,16 @@ jobs:
         if: "${{ success() }}"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-          COVERALLS_FLAG_NAME: python-${{ matrix.python }}
+          COVERALLS_FLAG_NAME: "python-${{ matrix.python }}"
           COVERALLS_PARALLEL: true
+      - name: Archive coverage results
+        uses: actions/upload-artifact@v4
+        with:
+          name: "coverage-${{ matrix.python }}"
+          path: test-reports
+      - name: Set status
+        if: steps.coverage.outcome == 'failure'
+        run: exit 1
     services:
       postgres:
         image: postgres:17.3
@@ -54,6 +64,7 @@ jobs:
         - '3.12.9'
   finish:
     needs: test
+    if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-python@v5.4.0
@@ -74,15 +85,29 @@ jobs:
         run: |
           make setup
           make setup_analysis
-      - name: Analysis and validation
-        run: |
-          make mypy
-          make pylint
-          scripts/validate_schema.sh samples receipt.yml
+      - name: Typing analysis and coverage (mypy)
+        id: mypy
+        continue-on-error: true
+        run: make mypy
+      - name: Code style (pylint)
+        id: pylint
+        continue-on-error: true
+        run: make pylint | tee pylint-report.txt
+      - name: Schema validation
+        run: scripts/validate_schema.sh samples receipt.yml
+      - name: Collect coverage results
+        uses: actions/download-artifact@v4
+        with:
+          pattern: coverage-*
+          path: test-reports
+          merge-multiple: true
       - name: SonarQube scan
         uses: SonarSource/sonarqube-scan-action@v4
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      - name: Set final status
+        if: steps.mypy.outcome == 'failure' || steps.pylint.outcome == 'failure'
+        run: exit 1
     strategy:
       matrix:
         python:

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ settings*.toml
 # Unit tests and coverage
 .coverage
 htmlcov/
+jsonschema_report_*.json
 pylint-report.txt
 test-reports/
 samples/2024-11-01-12-34-id.yml

--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,11 @@ MYPY=mypy
 PIP=python -m pip
 PYLINT=pylint
 RM=rm -rf
+SCRIPTS=scripts
 SOURCES=rechu
 TESTS=tests
-TEST=-m unittest discover -b -p '*.py' -s $(TESTS) -t .
+TEST_NAME?=pytest
+TEST=-m pytest $(TESTS) --junit-xml=test-reports/TEST-$(TEST_NAME).xml
 
 .PHONY: all
 all: coverage mypy pylint
@@ -35,13 +37,13 @@ install:
 
 .PHONY: pylint
 pylint:
-	$(PYLINT) $(SOURCES) $(TESTS) \
+	$(PYLINT) $(SOURCES) $(TESTS) $(SCRIPTS) \
 		--output-format=parseable \
 		-d duplicate-code
 
 .PHONY: mypy
 mypy:
-	$(MYPY) $(SOURCES) $(TESTS) \
+	$(MYPY) $(SOURCES) $(TESTS) $(SCRIPTS) \
 		--html-report mypy-report \
 		--cobertura-xml-report mypy-report \
 		--junit-xml mypy-report/TEST-junit.xml \
@@ -55,7 +57,7 @@ test:
 coverage:
 	$(COVERAGE) run --source=$(SOURCES) $(TEST)
 	$(COVERAGE) report -m
-	$(COVERAGE) xml -i -o test-reports/cobertura.xml
+	$(COVERAGE) xml -i -o test-reports/cobertura-$(TEST_NAME).xml
 
 .PHONY: build
 build:
@@ -66,6 +68,6 @@ clean:
 	# Unit tests and coverage
 	$(RM) .coverage htmlcov/ test-reports/
 	# Typing coverage and Pylint
-	$(RM) .mypy_cache mypy-report/ pylint-report.txt
+	$(RM) .mypy_cache mypy-report/ pylint-report.txt jsonschema_report_*.json
 	# Pip and distribution
 	$(RM) src/ build/ dist/ rechu.egg-info/

--- a/README.md
+++ b/README.md
@@ -74,8 +74,9 @@ The unit test coverage, typing coverage, style checks and schema validation is
 combined in one [GitHub Actions](https://github.com/lhelwerd/rechu/actions) 
 workflow which is run on commits to the main branch and pull request changes. 
 Unit test coverage is then stored for comparative purposes via the interface at 
-[Coveralls](https://coveralls.io/github/lhelwerd/rechu) and analysis results of 
-scans involved in a quality gate (including typing coverage) are made available 
+[Coveralls](https://coveralls.io/github/lhelwerd/rechu). The tests and coverage 
+results are combined with analysis results (including typing coverage by Mypy, 
+code style checks from Pylint and schema validation) as part of a quality gate 
 on [SonarCloud](https://sonarcloud.io/project/overview?id=lhelwerd_rechu).
 
 ## License

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,3 +50,8 @@ include = ["rechu*"]
 
 [tool.pylint]
 ignored-modules = ["alembic"]
+
+[tool.pytest.ini_options]
+testpaths = "tests"
+python_classes = "*Test"
+python_files = "*.py"

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,2 +1,4 @@
 coverage==7.6.4
 coveralls==4.0.1
+pytest==8.3.4
+pytest-subtests==0.14.1

--- a/schema/pyproject.json
+++ b/schema/pyproject.json
@@ -1,0 +1,9 @@
+{
+    "$id": "https://lhelwerd.github.io/rechu/schema/pyproject.json",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "Python packaging project configuration",
+    "$ref": "#/$defs/pyproject",
+    "$defs": {
+        "pyproject": {"$ref": "https://json.schemastore.org/pyproject.json"}
+    }
+}

--- a/scripts/format_json_schema_report.py
+++ b/scripts/format_json_schema_report.py
@@ -1,0 +1,136 @@
+"""
+Script to convert a `check-jsonschema` output report formatted as JSON into
+SonarQube server generic issue report format.
+"""
+
+import json
+from pathlib import Path
+import re
+import sys
+from typing import Union
+
+SchemaReport = dict[str, list[dict[str, str]]]
+Rule = dict[str, Union[str, list[dict[str, str]]]]
+Location = dict[str, Union[str, dict[str, int]]]
+Issue = dict[str, Union[str, int, Location, list[Location]]]
+GenericReport = dict[str, Union[list[Rule], list[Issue]]]
+
+ERROR_FILTER = re.compile(r"\d\.\d\d? is not a multiple of 0\.01")
+
+def _parse_error(rules: dict[str, Rule], issues: list[Issue],
+                 error: dict[str, str], root: Path) -> None:
+    try:
+        path = Path(error["filename"]).resolve().relative_to(root, walk_up=True)
+    except ValueError:
+        # Ignore files outside the repository root, probably not tracked
+        return
+
+    location: Location = {
+        "message": error["message"],
+        "filePath": str(path)
+    }
+    if "path" in error:
+        rules["json_validate_error"] = {
+            "id": "json_validate_error",
+            "name": "JSON schema validation error",
+            "description": "JSON schema detected a nonconforming element.",
+            "engineId": "check-jsonschema",
+            "cleanCodeAttribute": "CONVENTIONAL",
+            "impacts": [
+                {
+                    "softwareQuality": "RELIABILITY",
+                    "severity": "LOW"
+                }
+            ],
+            "type": "BUG",
+            "severity": "MINOR"
+        }
+        location["message"] = f'{error["message"]}. JSON path: {error["path"]}'
+        issues.append({
+            "ruleId": "json_validate_error",
+            "primaryLocation": location
+        })
+    else:
+        rules["json_parse_error"] = {
+            "id": "json_parse_error",
+            "name": "JSON schema parsing error",
+            "description": "A JSON, TOML or YAML file could not be parsed.",
+            "engineId": "check-jsonschema",
+            "cleanCodeAttribute": "LOGICAL",
+            "impacts": [
+                {
+                    "softwareQuality": "RELIABILITY",
+                    "severity": "HIGH"
+                }
+            ],
+            "type": "BUG",
+            "severity": "MAJOR"
+        }
+
+        # Locate the parse error by parsing the affected file ourselves
+        try:
+            with Path(error["filename"]).open('r',
+                                              encoding='utf-8') as parse_file:
+                json.load(parse_file)
+        except json.decoder.JSONDecodeError as parse_error:
+            location["message"] = f"Failed to parse file: {parse_error.msg}"
+            location["textRange"] = {
+                "startLine": parse_error.lineno,
+                "startColumn": parse_error.colno
+            }
+
+        issues.append({
+            "ruleId": "json_parse_error",
+            "primaryLocation": location
+        })
+
+def main(argv: list[str]) -> int:
+    """
+    Main entry point.
+    """
+
+    usage = ("check-jsonschema --output-format json ... | \n"
+             "  python scripts/format_json_schema_report.py <schema> [root]")
+    if not argv or sys.stdin.isatty():
+        print(f"Usage: {usage}", file=sys.stderr)
+        return 1
+
+    schema = argv[0]
+    root = Path(argv[1]) if len(argv) > 1 else \
+        Path(__file__).resolve().parent.parent
+    try:
+        report: SchemaReport = json.load(sys.stdin)
+    except json.decoder.JSONDecodeError as parse_error:
+        print(f"Could not parse report from standard input: {parse_error}",
+              file=sys.stderr)
+        report = {
+            "parse_errors": [
+                {
+                    "filename": schema,
+                    "message": ""
+                }
+            ]
+        }
+
+    rules: dict[str, Rule] = {}
+    issues: list[Issue] = []
+    for error_type in ("errors", "parse_errors"):
+        for error in report.get(error_type, []):
+            if schema != "schema/receipt.json" or \
+                not ERROR_FILTER.match(error["message"]):
+                _parse_error(rules, issues, error, root)
+
+    output: GenericReport = {
+        "rules": list(rules.values()),
+        "issues": issues
+    }
+
+    output_filename = f"jsonschema_report_{Path(schema).stem}.json"
+    with Path(output_filename).open("w", encoding="utf-8") as output_path:
+        json.dump(output, output_path)
+
+    print(f"Generated SonarQube generic report in {output_filename}")
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/validate_schema.sh
+++ b/scripts/validate_schema.sh
@@ -2,12 +2,21 @@
 
 # Script to validate JSON schemas and the YAML files against those schemas.
 
+PYTHON=python
+if ! command -v $PYTHON 2>&1 >/dev/null; then
+	PYTHON=python3
+	if ! command -v $PYTHON 2>&1 >/dev/null; then
+		echo "This command can only be run in a Python 3 environment." >&2
+		exit 1
+	fi
+fi
+
 realpath() {
 	if [ ! -e "$1" ]; then
 		echo "Error: Path '$1' does not exist" >&2
 		return 1
 	fi
-	python -c "import os, sys;print(os.path.realpath(sys.argv[1]))" "$1"
+	$PYTHON -c "import os, sys;print(os.path.realpath(sys.argv[1]))" "$1"
 }
 
 SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
@@ -29,20 +38,63 @@ if [ ! -f "$DATA_DIR/$DATA_PATTERN" ]; then
 	DATA_PATTERN="$DATA_PATTERN/*.yml"
 fi
 
-echo "Validating schemas in $ROOT_DIR/schema against metaschema"
-check-jsonschema --check-metaschema $ROOT_DIR/schema/*.json
+check() {
+	schema=$1
+	shift
+	files=$*
+	if [ "$schema" = "meta" ]; then
+		args="--check-metaschema"
+	else
+		args="--schemafile $ROOT_DIR/$schema"
+	fi
+	if [ -t 0 ]; then
+		args="$args --color always"
+		green=$'\033[1;32m'
+		off=$'\e[m'
+	else
+		green=""
+		off=""
+	fi
+	set +e
+	if [ "$schema" = "schema/receipt.json" ]; then
+		output=$(check-jsonschema $args $files 2>&1 | grep -v "\d.\d\d\? is not a multiple of 0.01" | sed -e "$ s/^Schema validation errors were encountered.$//")
+		if [ "$output" = "" ]; then
+			echo "${green}ok${off} -- validation done"
+			code=0
+		else
+			echo "$output"
+			code=1
+		fi
+	else
+		check-jsonschema $args $files
+		code=$?
+	fi
+	if [ $code -ne 0 ]; then
+		check-jsonschema --output-format json $args $files 2>/dev/null | $PYTHON $ROOT_DIR/scripts/format_json_schema_report.py $schema
+	else
+		echo '{}' | $PYTHON $ROOT_DIR/scripts/format_json_schema_report.py $schema
+	fi
+	set -e
+}
 
-echo "Validating settings.toml, settings.toml.example and settings.toml.test"
+echo "Validating schemas in $ROOT_DIR/schema against metaschema"
+check meta schema/*.json
+
 if [ -f "$ROOT_DIR/settings.toml" ]; then
-	check-jsonschema --schemafile $ROOT_DIR/schema/settings.json $ROOT_DIR/settings.toml
+	echo "Validating settings.toml"
+	check schema/settings.json $ROOT_DIR/settings.toml
 fi
-check-jsonschema --schemafile $ROOT_DIR/schema/settings.json --default-filetype toml $ROOT_DIR/settings.toml.{example,test}
+echo "Validating settings.toml.example and settings.toml.test"
+check schema/settings.json --default-filetype toml $ROOT_DIR/settings.toml.{example,test}
 
 echo "Validating $DATA_DIR/products.yml"
-check-jsonschema --schemafile $ROOT_DIR/schema/products.json $DATA_DIR/products.yml
+check schema/products.json $DATA_DIR/products.yml
 
 echo "Validating receipts in $DATA_DIR/$DATA_PATTERN"
 # Ignore multipleOf errors for values that have less precision than 0.01
 green=$'\033[1;32m'
 off=$'\e[m'
-check-jsonschema --color always --schemafile $ROOT_DIR/schema/receipt.json $DATA_DIR/$DATA_PATTERN | grep -v "\d.\d\d\? is not a multiple of 0.01" | sed -e "$ s/^Schema validation errors were encountered.$/${green}ok${off} -- validation done/"
+check schema/receipt.json $DATA_DIR/$DATA_PATTERN
+
+echo "Validating pyproject.toml"
+check schema/pyproject.json $ROOT_DIR/pyproject.toml

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,11 +4,11 @@ sonar.organization=lhelwerd
 sonar.projectName=Receipt cataloging hub
 sonar.projectVersion=0.0.0
 
-sonar.sources=rechu
+sonar.sources=rechu,schema,scripts,pyproject.toml,settings.toml.example,settings.toml.test
 sonar.tests=tests
 sonar.python.version=3
-sonar.python.pylint_config=.pylintrc
 sonar.python.pylint.reportPaths=pylint-report.txt
 sonar.python.xunit.reportPath=*-report*/TEST-*.xml
 sonar.python.xunit.skipDetails=true
-sonar.python.coverage.reportPaths=*-report*/cobertura.xml
+sonar.python.coverage.reportPaths=*-report*/cobertura*.xml
+sonar.externalIssuesReportPaths=jsonschema_report_meta.json,jsonschema_report_settings.json,jsonschema_report_products.json,jsonschema_report_receipt.json,jsonschema_report_pyproject.json


### PR DESCRIPTION
- Archive the coverage results of the jobs with identifying names
- Collect all the coverage artifacts in the finish job
- Do not error out from analysis/validation so that SonarQube scan can still take place
- Actually create pylint report file for SonarCloud
- Include JSON schema validation issues using SonarQube generic report
