### PR TITLE
Models: Add string representation, total price and correct precision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,3 +18,7 @@ and we adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Add cascade deletes for receipt products/discounts.
+
+### Fixed
+
+- Correct precision of prices during serialization

--- a/rechu/io/base.py
+++ b/rechu/io/base.py
@@ -9,7 +9,7 @@ import os
 from pathlib import Path
 from typing import Any, Generic, IO, Optional, TypeVar
 import yaml
-from rechu.models import Base
+from rechu.models.base import Base, Price
 
 T = TypeVar('T', bound=Base)
 
@@ -90,10 +90,15 @@ class YAMLWriter(Writer[T], metaclass=ABCMeta):
     YAML file writer.
     """
 
+    @staticmethod
+    def _represent_price(dumper: yaml.Dumper, data: Price) -> yaml.Node:
+        return dumper.represent_scalar('tag:yaml.org,2002:float', str(data))
+
     def save(self, data: Any, file: IO) -> None:
         """
         Save the YAML file from a Python value.
         """
 
+        yaml.add_representer(Price, self._represent_price)
         yaml.dump(data, file, width=80, indent=2, default_flow_style=None,
                   sort_keys=False)

--- a/rechu/io/receipt.py
+++ b/rechu/io/receipt.py
@@ -22,7 +22,8 @@ class ReceiptReader(YAMLReader[Receipt]):
         receipt = Receipt(filename=self._path.name, updated=self._updated,
                           date=data['date'], shop=str(data['shop']))
         receipt.products = [
-            ProductItem(quantity=str(item[0]), label=item[1], price=item[2],
+            ProductItem(quantity=str(item[0]), label=item[1],
+                        price=Price(item[2]),
                         discount_indicator=item[3] if len(item) > 3 else None)
             for item in data['products']
         ]
@@ -34,7 +35,7 @@ class ReceiptReader(YAMLReader[Receipt]):
 
     def _discount(self, item: list[Union[str, float]],
                   products: list[ProductItem]) -> Discount:
-        discount = Discount(label=str(item[0]), price_decrease=float(item[1]))
+        discount = Discount(label=str(item[0]), price_decrease=Price(item[1]))
         seen = 0
         for label in item[2:]:
             for index, product in enumerate(products[seen:]):

--- a/rechu/models/base.py
+++ b/rechu/models/base.py
@@ -3,12 +3,21 @@ Base model for receipt cataloging.
 """
 
 from decimal import Decimal
-from typing import Annotated
+from typing import Union
 from sqlalchemy import MetaData, Numeric
 from sqlalchemy.orm import DeclarativeBase, registry
 
-# Price type with scale of 2 (number of decimal places)
-Price = Annotated[Decimal, 2]
+_PriceNew = Union[Decimal, float, str]
+
+class Price(Decimal):
+    """
+    Price type with scale of 2 (number of decimal places).
+    """
+
+    _quantize = Decimal('1.00')
+
+    def __new__(cls, value: _PriceNew) -> "Price":
+        return super().__new__(cls, Decimal(value).quantize(cls._quantize))
 
 class Base(DeclarativeBase): # pylint: disable=too-few-public-methods
     """

--- a/rechu/models/shop.py
+++ b/rechu/models/shop.py
@@ -18,3 +18,7 @@ class Shop(Base): # pylint: disable=too-few-public-methods
     name: Mapped[Optional[str]] = mapped_column(String(32))
     website: Mapped[Optional[str]]
     wikidata: Mapped[Optional[str]]
+
+    def __repr__(self) -> str:
+        return (f"Shop(key={self.key!r}, name={self.name!r}, "
+                f"website={self.website!r}, wikidata={self.wikidata!r})")

--- a/samples/receipt.yml
+++ b/samples/receipt.yml
@@ -1,14 +1,14 @@
 date: 2024-11-01
 shop: id
 products:
-  - [1, label, 0.99]
-  - [2, bulk, 5.00, bonus]
-  - [3, bulk, 7.50]
-  - [4, bulk, 8.00, bonus]
-  - [0.750kg, weigh, 2.50]
-  - [1, due, 0.89, 25%]
+- [1, label, 0.99]
+- [2, bulk, 5.00, bonus]
+- [3, bulk, 7.50]
+- [4, bulk, 8.00, bonus]
+- [0.750kg, weigh, 2.50]
+- [1, due, 0.89, 25%]
 bonus:
-  - [disco, -2.00, bulk, bulk]
-  - [over, -0.22, due]
-  - [none, -0.02]
-  - [missing, -0.20, other]
+- [disco, -2.00, bulk, bulk]
+- [over, -0.22, due]
+- [none, -0.02]
+- [missing, -0.20, other]

--- a/tests/command/new.py
+++ b/tests/command/new.py
@@ -3,14 +3,14 @@ Tests of subcommand to create a new receipt YAML file and import it.
 """
 
 from datetime import datetime
-from decimal import Decimal
 from io import StringIO
 from pathlib import Path
 from unittest.mock import patch
 from sqlalchemy import select
 import yaml
 from rechu.command.new import New
-from rechu.models import Receipt
+from rechu.models.base import Price
+from rechu.models.receipt import Receipt
 from ..database import DatabaseTestCase
 
 class NewTest(DatabaseTestCase):
@@ -77,7 +77,7 @@ class NewTest(DatabaseTestCase):
                     self.fail("Expected receipt to be stored")
                 self.assertEqual(receipt.filename, self.path.name)
                 self.assertEqual(len(receipt.products), 1)
-                self.assertEqual(receipt.products[0].price, Decimal('0.01'))
+                self.assertEqual(receipt.products[0].price, Price('0.01'))
 
     def test_get_completion(self) -> None:
         """

--- a/tests/models/__init__.py
+++ b/tests/models/__init__.py
@@ -1,0 +1,3 @@
+"""
+Tests for receipt cataloging models.
+"""

--- a/tests/models/shop.py
+++ b/tests/models/shop.py
@@ -1,0 +1,21 @@
+"""
+Tests for shop metadata models.
+"""
+
+import unittest
+from rechu.models.shop import Shop
+
+class ShopTest(unittest.TestCase):
+    """
+    Tests for shop metadata model.
+    """
+
+    def test_repr(self) -> None:
+        """
+        Test the string representation of the model.
+        """
+
+        self.assertEqual(repr(Shop(key='id', name='Generic Shop',
+                                   website='https://shop.example')),
+                         "Shop(key='id', name='Generic Shop', "
+                         "website='https://shop.example', wikidata=None)")


### PR DESCRIPTION
- Models can now be represented as a string with their main properties
- Add property for total price of a receipt
- Ensure prices keep precision after serialization and database commit
- Add CHANGELOG.md entry on price precision