### PR TITLE
Dump command to export receipt YAML files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ test-reports/
 samples/2024-11-01-12-34-id.yml
 samples/new_receipt.yml
 samples/receipt-[12].yml
+tmp/
 
 # Typing coverage and Pylint
 .mypy_cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and we adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Receipt database dump through a subcommand added.
 - Support for PostgreSQL added.
 - Receipt file and database entry deletion through a subcommand added.
 - Database migration support using Alembic through a subcommand added.

--- a/rechu/command/__init__.py
+++ b/rechu/command/__init__.py
@@ -6,6 +6,7 @@ from .base import Base
 from .alembic import Alembic
 from .create import Create
 from .delete import Delete
+from .dump import Dump
 from .new import New
 from .read import Read
 

--- a/rechu/command/dump.py
+++ b/rechu/command/dump.py
@@ -1,0 +1,59 @@
+"""
+Subcommand to export database entries as YAML files.
+"""
+
+from pathlib import Path
+from sqlalchemy import select
+from .base import Base
+from ..database import Database
+from ..io.receipt import ReceiptWriter
+from ..models.receipt import Receipt
+
+@Base.register("dump")
+class Dump(Base):
+    """
+    Dump YAML files from the database.
+    """
+
+    subparser_keywords = {
+        'help': 'Export entities from the database',
+        'description': 'Create one or more YAML files for data in the database.'
+    }
+    subparser_arguments = [
+        ('files', {
+            'metavar': 'FILE',
+            'nargs': '*',
+            'help': 'One or more receipts to write; if none are provided, then '
+                    'the entire database is dumped'
+        })
+    ]
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.files: list[str] = []
+
+    def run(self) -> None:
+        data_path = Path(self.settings.get('data', 'path'))
+        data_format = self.settings.get('data', 'format')
+
+        # Filter off path elements to just keep the file name
+        files = tuple(Path(file).name for file in self.files)
+
+        directories: set[Path] = set()
+        with Database() as session:
+            receipts = select(Receipt)
+            if files:
+                receipts = receipts.where(Receipt.filename.in_(files))
+            for receipt in session.scalars(receipts):
+                path_format = data_path / data_format.format(date=receipt.date,
+                                                             shop=receipt.shop)
+                path = path_format.parent / receipt.filename
+                # Only write new files, do not overwrite existing ones
+                if not path.exists():
+                    if path.parent not in directories:
+                        # Create directories when needed, cache directories
+                        path.parent.mkdir(parents=True, exist_ok=True)
+                        directories.add(path.parent)
+
+                    writer = ReceiptWriter(path, receipt)
+                    writer.write()

--- a/rechu/database.py
+++ b/rechu/database.py
@@ -98,5 +98,10 @@ class Database:
             self.session.close()
             self.session = None
 
+    def clear(self) -> None:
+        """
+        Reset any permanent settings-based state of the database.
+        """
+
         if event.contains(Engine, "connect", self._set_sqlite_pragma):
             event.remove(Engine, "connect", self._set_sqlite_pragma)

--- a/rechu/io/receipt.py
+++ b/rechu/io/receipt.py
@@ -63,15 +63,16 @@ class ReceiptWriter(YAMLWriter[Receipt]):
         else:
             quantity = product.quantity
         if product.discount_indicator is None:
-            return [quantity, product.label, product.price]
+            return [quantity, product.label, Price(product.price)]
         return [
-            quantity, product.label, product.price, product.discount_indicator
+            quantity, product.label, Price(product.price),
+            product.discount_indicator
         ]
 
     @staticmethod
     def _get_discount(discount: Discount) -> list[Union[str, Price]]:
         data: list[Union[str, Price]] = [
-            discount.label, discount.price_decrease
+            discount.label, Price(discount.price_decrease)
         ]
         data.extend([item.label for item in discount.items])
         return data

--- a/tests/command/alembic.py
+++ b/tests/command/alembic.py
@@ -56,6 +56,8 @@ class AlembicTest(DatabaseTestCase):
         alembic.run()
 
         Settings.clear()
+        self.database.clear()
+
         with patch.dict('os.environ',
                         {'RECHU_DATABASE_URI': 'sqlite+pysqlite:///mock.db'}):
             alembic.args = ["upgrade", "--sql", "base:head"]
@@ -64,6 +66,8 @@ class AlembicTest(DatabaseTestCase):
                     alembic.run()
                     self.assertIn("Offline mode not supported for SQLite",
                                   stdout)
+
+        self.database.clear()
 
         url = "postgresql+psycopg://"
         engine = create_mock_engine(url, MagicMock())

--- a/tests/command/dump.py
+++ b/tests/command/dump.py
@@ -1,0 +1,74 @@
+"""
+Tests of subcommand to export database entries as YAML files.
+"""
+
+from datetime import datetime
+from itertools import zip_longest
+import os
+from pathlib import Path
+import shutil
+from unittest.mock import patch
+from rechu.command.dump import Dump
+from rechu.io.receipt import ReceiptReader
+from ..database import DatabaseTestCase
+
+class DumpTest(DatabaseTestCase):
+    """
+    Test dumping YAML files from the database.
+    """
+
+    path = Path("tmp")
+    copy = Path("samples/receipt-1.yml")
+
+    def tearDown(self) -> None:
+        super().tearDown()
+        shutil.rmtree(self.path, ignore_errors=True)
+        self.copy.unlink(missing_ok=True)
+
+    @patch.dict('os.environ', {'RECHU_DATA_PATH': 'tmp'})
+    def test_run(self) -> None:
+        """
+        Test executing the command.
+        """
+
+        path = Path("samples/receipt.yml").resolve()
+        now = datetime.now()
+
+        with self.database as session:
+            session.add(next(ReceiptReader(path, updated=now).read()))
+            self.copy.symlink_to(path.name)
+            self.assertEqual(self.copy.resolve(), path)
+            session.add(next(ReceiptReader(self.copy, updated=now).read()))
+
+        command = Dump()
+        command.run()
+
+        # The original filename is preferred over the date format.
+        dump_path = self.path / "samples" / "receipt.yml"
+        copy_path = self.path / "samples" / "receipt-1.yml"
+        self.assertTrue(dump_path.exists())
+        self.assertTrue(copy_path.exists())
+
+        with path.open("r", encoding="utf-8") as source_file:
+            with dump_path.open("r", encoding="utf-8") as dump_file:
+                for (line, (source, dump)) in enumerate(zip_longest(source_file,
+                                                                    dump_file)):
+                    with self.subTest(line=line):
+                        self.assertEqual(source.replace(", other", ""), dump)
+
+        os.utime(dump_path, times=(now.timestamp() + 1, now.timestamp() + 1))
+
+        command = Dump()
+        command.files = ["receipt.yml"]
+        command.run()
+
+        # Existing file is not overridden or has its modification date changed.
+        self.assertEqual(dump_path.stat().st_mtime, now.timestamp() + 1)
+        self.assertEqual(copy_path.stat().st_mtime, now.timestamp())
+
+        command = Dump()
+        command.files = ["2025-02-31-12-34-mia.yml"]
+        command.run()
+
+        missing_path = self.path / "samples" / "2025-02-31-12-34-mia.yml"
+        self.assertFalse(missing_path.exists())


### PR DESCRIPTION
- Write all, one or some receipts based on filenames, use original names instead of filename pattern which might lead to zeros in date fields.
- Ensure prices are serialized as floats with two precision instead of decimal objects.