### PR TITLE
Match products with respect to quantity and unit, not to discounts (during new products step) and duplicates (in corner cases)

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,3 +4,4 @@ branch = True
 exclude_also =
 	if TYPE_CHECKING:
 	except ImportError:
+	\.\.\.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ and we adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Prices of products on receipts are compared against prices in product 
+  metadata after dividing the former by the amount of the item, if possible; 
+  for quantities with units, the product item must have the normalized unit.
 - Add cascade deletes for receipt products/discounts.
 
 ### Fixed

--- a/docs/source/commands.md
+++ b/docs/source/commands.md
@@ -38,22 +38,24 @@ the correct base revision to perform the relevant further migrations from.
 Database upgrades are described in the <project:#alembic> section.
 
 (new)=
-## New: Create receipts
+## New receipts and products
 
 When your database is available and ready, you are able start filling it in 
-with receipt information. If you have not created any YAML files for them yet, 
-then one method of creating them and adding them to the database in one go is 
-using `rechu new`.
+with receipt information, including product items, discounts and additional 
+metadata. If you have not created any YAML files containing this data yet, then 
+one method of creating them and adding them to the database in one go is using 
+`rechu new`.
 
 This command will interactively query you on properties of a receipt that you 
-create. This includes metadata of the receipt, such as the date and shop from 
-which the receipt was obtained, but also product details and possible 
+create. This includes primary metadata of the receipt, such as the date and 
+shop from which the receipt was obtained, but also product details and possible 
 discounts. For products, additional metadata that matches products on the 
-current and other receipts can also be input After all portions have been 
-filled in, a YAML file is generated for the receipt, product metadata is added 
-to separate YAML files and the receipt is imported into the database, as well 
-as any related entities and their relations, such as product items, discounts 
-and metadata matching fields.
+current and other receipts can also be input. After all portions have been 
+filled in, a YAML file is generated for the receipt and product metadata is 
+added to a separate YAML inventory file (or several files if the data products 
+setting contains multiple format specifications). Additionally, the receipt is 
+imported into the database, as well as any related entities and their 
+relations, such as product items, discounts and metadata matching fields.
 
 The process to fill in all the information may be somewhat tedious. At various 
 points, you can choose to move to the next portion of a receipt (which is 
@@ -81,10 +83,12 @@ listed on the receipt) will display the YAML format and return you to the menu.
 It's possible to exit the process by entering `quit` in the menu (with 
 a confirmation if the `-c` argument is provided) or pressing `Ctrl+C` at any 
 point. The receipt is discarded and you are able to start again from scratch. 
-If you created a faulty receipt or product metadata, then you could either edit 
-the corresponding YAML file and synchronize it by [reading files](#read), or 
-you can use another command to [delete](#delete) the receipt YAML file and 
-database entry.
+Product metadata is only accepted if it matches the current product or later on 
+any product on the receipt without leading to duplicate matches. If you wrote 
+a faulty receipt or product metadata, then you could either externally edit the 
+corresponding YAML file and synchronize it by [reading files](#read), or you 
+can use another command to [delete](#delete) the receipt YAML file and database 
+entry.
 
 :::{tip}
 In the menu, all steps are also recognized if only a number of initial 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ license = {text = "MIT"}
 requires-python = ">=3.9"
 dependencies = [
     "alembic==1.14.1",
+    "Pint==0.24.4",
     "python-dateutil==2.9.0.post0",
     "PyYAML==6.0.2",
     "SQLAlchemy==2.0.36",

--- a/rechu/alembic/versions/3b0cfa853967_increase_gtin_size.py
+++ b/rechu/alembic/versions/3b0cfa853967_increase_gtin_size.py
@@ -11,6 +11,7 @@ from typing import Sequence, Union
 
 from alembic import op
 import sqlalchemy as sa
+from sqlalchemy.sql import column, table
 
 
 # Revision identifiers, used by Alembic.
@@ -40,6 +41,9 @@ def downgrade() -> None:
     """
 
     with op.batch_alter_table('product', schema=None) as batch_op:
+        product = table('product', column('id', sa.Integer()),
+                        column('gtin', sa.BigInteger()))
+        batch_op.execute(product.update().values(gtin=None))
         batch_op.alter_column('gtin',
                               existing_type=sa.BigInteger(),
                               type_=sa.INTEGER(),

--- a/rechu/alembic/versions/8ef12eb24650_add_receipt_item_extracted_quantity_.py
+++ b/rechu/alembic/versions/8ef12eb24650_add_receipt_item_extracted_quantity_.py
@@ -1,0 +1,115 @@
+"""
+Add receipt item extracted quantity fields
+
+Revision ID: 8ef12eb24650
+Revises: b1a7a91c8de8
+Create Date: 2025-05-29 22:55:58.519845
+"""
+# pylint: disable=invalid-name
+
+from typing import Sequence, Union
+
+from alembic import context, op
+from alembic.operations import BatchOperations
+import sqlalchemy as sa
+from sqlalchemy.sql import TableClause, table, column
+from rechu.database import Database
+from rechu.models.base import Quantity
+
+# Revision identifiers, used by Alembic.
+revision: str = '8ef12eb24650'
+down_revision: Union[str, None] = 'b1a7a91c8de8'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+Amounts = list[dict[str, Union[float, str]]]
+Units = list[dict[str, Union[int, str]]]
+
+def upgrade() -> None:
+    """
+    Perform the upgrade.
+    """
+
+    product = table('receipt_product', column('id', sa.Integer()),
+                    column('quantity', sa.String()),
+                    column('amount', sa.Float()),
+                    column('unit', sa.String()))
+    amounts, units = collect_quantity(product)
+
+    with op.batch_alter_table('receipt_product', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('amount', sa.Float(), nullable=True))
+
+    with op.batch_alter_table('receipt_product', schema=None) as batch_op:
+        update_amount(batch_op, product, amounts)
+
+    with op.batch_alter_table('receipt_product', schema=None) as batch_op:
+        batch_op.alter_column('amount',
+                              existing_type=sa.Float(),
+                              existing_nullable=True,
+                              nullable=False)
+        batch_op.add_column(sa.Column('unit', sa.String(), nullable=True))
+
+    with op.batch_alter_table('receipt_product', schema=None) as batch_op:
+        update_unit(batch_op, product, units)
+
+    # ### end Alembic commands ###
+
+def collect_quantity(product: TableClause) -> tuple[Amounts, Units]:
+    """
+    Extract quantity fields.
+    """
+
+    amounts = []
+    units = []
+    with Database() as session:
+        if context.is_offline_mode():
+            connection = session.connection()
+        else:
+            connection = op.get_bind()
+        for row in connection.execute(sa.select(product.c.id,
+                                                product.c.quantity)):
+            quantity = Quantity(row.quantity)
+            amounts.append({
+                "row_id": row.id,
+                "amount": quantity.amount
+            })
+            if quantity.unit is not None:
+                units.append({
+                    "row_id": row.id,
+                    "unit": str(quantity.unit)
+                })
+
+    return amounts, units
+
+def update_amount(batch_op: BatchOperations, product: TableClause,
+                  amounts: Amounts) -> None:
+    """
+    Update the amount column.
+    """
+
+    for amount in amounts:
+        batch_op.execute(product.update()
+                         .where(product.c.id == amount["row_id"])
+                         .values({"amount": amount["amount"]}))
+
+def update_unit(batch_op: BatchOperations, product: TableClause,
+                units: Units) -> None:
+    """
+    Update the unit column.
+    """
+
+    for unit in units:
+        batch_op.execute(product.update()
+                         .where(product.c.id == unit["row_id"])
+                         .values({"unit": unit["unit"]}))
+
+def downgrade() -> None:
+    """
+    Perform the downgrade.
+    """
+
+    with op.batch_alter_table('receipt_product', schema=None) as batch_op:
+        batch_op.drop_column('unit')
+        batch_op.drop_column('amount')
+
+    # ### end Alembic commands ###

--- a/rechu/alembic/versions/9d5f6a8f4944_drop_foreign_key_for_receipt_shop.py
+++ b/rechu/alembic/versions/9d5f6a8f4944_drop_foreign_key_for_receipt_shop.py
@@ -10,6 +10,8 @@ Create Date: 2025-02-10 20:23:02.768133
 from typing import Sequence, Union
 
 from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.sql import column, table
 
 # Revision identifiers, used by Alembic.
 revision: str = '9d5f6a8f4944'
@@ -35,6 +37,10 @@ def downgrade() -> None:
     """
 
     with op.batch_alter_table('receipt', schema=None) as batch_op:
+        receipt = table('receipt', column('shop', sa.String(32)))
+        shop = table('shop', column('key', sa.String(32)))
+        select = sa.select(receipt.c.shop.label("key")).distinct()
+        batch_op.execute(shop.insert().from_select(["key"], select))
         batch_op.create_foreign_key('fk_receipt_shop_shop', 'shop', ['shop'],
                                     ['key'])
 

--- a/rechu/matcher/base.py
+++ b/rechu/matcher/base.py
@@ -26,13 +26,15 @@ class Matcher(Generic[IT, CT]):
             -> Iterator[tuple[CT, IT]]:
         """
         Detect candidate models in the database that match items. Optionally,
-        the `items` may be provided, which might not be inserted or updated in
-        the database, otherwise all items from the database are attempted for
-        matching. Similarly, `extra` candidates may be provided, which in their
-        case augment those from the database. If `only_unmatched` is enabled,
-        then only items that do not have a relation with a candidate model are
-        attempted for matching. The resulting iterator provides tuples of
-        matches between candidates and items which have not been updated yet.
+        the `items` may be provided, which might not have been inserted or
+        updated in the database, otherwise all items from the database are
+        attempted for matching. Moreover, `extra` candidates may be provided,
+        which in their case augment those from the database. If `only_unmatched`
+        is enabled, then only items that do not have a relation with a candidate
+        model are attempted for matching. The resulting iterator provides tuples
+        of matches between candidates and items which have not had an update to
+        their match relationship yet; multiple candidate models may be indicated
+        for a single item model.
         """
 
         raise NotImplementedError('Search must be implemented by subclasses')

--- a/rechu/models/base.py
+++ b/rechu/models/base.py
@@ -2,27 +2,11 @@
 Base model for receipt cataloging.
 """
 
-from decimal import Decimal
-from typing import Union
-from sqlalchemy import BigInteger, MetaData, Numeric
+from sqlalchemy import MetaData
 from sqlalchemy.orm import DeclarativeBase, registry
+from ..types.measurable import Quantity, Unit, QuantityType, UnitType
+from ..types.quantized import GTIN, Price, GTINType, PriceType
 
-_PriceNew = Union[Decimal, float, str]
-
-class Price(Decimal):
-    """
-    Price type with scale of 2 (number of decimal places).
-    """
-
-    _quantize = Decimal('1.00')
-
-    def __new__(cls, value: _PriceNew) -> "Price":
-        return super().__new__(cls, Decimal(value).quantize(cls._quantize))
-
-class GTIN(int):
-    """
-    Global trade item number identifier for products.
-    """
 
 class Base(DeclarativeBase): # pylint: disable=too-few-public-methods
     """
@@ -38,6 +22,8 @@ class Base(DeclarativeBase): # pylint: disable=too-few-public-methods
     })
 
     registry = registry(type_annotation_map={
-        Price: Numeric(None, 2),
-        GTIN: BigInteger
+        Price: PriceType,
+        Quantity: QuantityType,
+        Unit: UnitType,
+        GTIN: GTINType
     })

--- a/rechu/models/shop.py
+++ b/rechu/models/shop.py
@@ -4,7 +4,7 @@ Models for shop metadata.
 
 from typing import Optional
 from sqlalchemy import String
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.orm import MappedColumn, mapped_column
 from .base import Base
 
 class Shop(Base): # pylint: disable=too-few-public-methods
@@ -14,10 +14,10 @@ class Shop(Base): # pylint: disable=too-few-public-methods
 
     __tablename__ = "shop"
 
-    key: Mapped[str] = mapped_column(String(32), primary_key=True)
-    name: Mapped[Optional[str]] = mapped_column(String(32))
-    website: Mapped[Optional[str]]
-    wikidata: Mapped[Optional[str]]
+    key: MappedColumn[str] = mapped_column(String(32), primary_key=True)
+    name: MappedColumn[Optional[str]] = mapped_column(String(32))
+    website: MappedColumn[Optional[str]]
+    wikidata: MappedColumn[Optional[str]]
 
     def __repr__(self) -> str:
         return (f"Shop(key={self.key!r}, name={self.name!r}, "

--- a/rechu/types/__init__.py
+++ b/rechu/types/__init__.py
@@ -1,0 +1,3 @@
+"""
+Attribute types for model properties.
+"""

--- a/rechu/types/decorator.py
+++ b/rechu/types/decorator.py
@@ -1,0 +1,69 @@
+"""
+Type decorators for model type annotation maps.
+"""
+
+from typing import Any, Generic, Optional, Protocol, TypeVar
+from sqlalchemy.engine import Dialect
+from sqlalchemy.types import String, TypeDecorator, TypeEngine
+from typing_extensions import Self
+
+class Convertible(Protocol):
+    # pylint: disable=too-few-public-methods
+    """
+    A type which can be created from another input type.
+    """
+
+    def __new__(cls: type[Self], value: object) -> Self:
+        ...
+
+T = TypeVar('T', bound=Convertible)
+ST = TypeVar('ST', bound=Convertible)
+
+class SerializableType(TypeDecorator[T], Generic[T, ST]):
+    # pylint: disable=too-many-ancestors
+    """
+    Type decoration handler for attributes.
+    """
+
+    # Default implementation
+    impl: TypeEngine = String()
+
+    def process_literal_param(self, value: Optional[T],
+                              dialect: Dialect) -> str:
+        if value is None:
+            return "NULL"
+        processor = self.impl.literal_processor(dialect)
+        if processor is None: # pragma: no cover
+            raise TypeError("There should be a literal processor for SQL type")
+        return processor(self.serialized_type(value))
+
+    def process_bind_param(self, value: Optional[T], dialect: Dialect) -> Any:
+        if value is None:
+            return None
+        return self.serialized_type(value)
+
+    def process_result_value(self, value: Optional[Any],
+                             dialect: Dialect) -> Optional[T]:
+        if value is None:
+            return None
+        return self.serializable_type(value)
+
+    @property
+    def python_type(self) -> type[Any]:
+        return self.serializable_type
+
+    @property
+    def serializable_type(self) -> type[T]:
+        """
+        Retrieve the type to use for result values of this serialized type.
+        """
+
+        raise NotImplementedError("Must be implemented by subclasses")
+
+    @property
+    def serialized_type(self) -> type[ST]:
+        """
+        Retrieve the type to use for storing the values in the database.
+        """
+
+        raise NotImplementedError("Must be implemented by subclasses")

--- a/rechu/types/measurable/__init__.py
+++ b/rechu/types/measurable/__init__.py
@@ -1,0 +1,9 @@
+"""
+Attribute types for measurable values such as quantities and units.
+"""
+
+from .decorator import QuantityType, UnitType
+from .quantity import Quantity
+from .unit import Unit
+
+__all__ = ["Quantity", "Unit", "QuantityType", "UnitType"]

--- a/rechu/types/measurable/base.py
+++ b/rechu/types/measurable/base.py
@@ -1,0 +1,90 @@
+"""
+Base type for measurable quantities and units.
+"""
+
+from decimal import Decimal
+from typing import Callable, Generic, TypeVar, Union
+import pint
+from pint.facets.plain import PlainQuantity, PlainUnit
+from typing_extensions import Self, TypeGuard
+
+Dimension = Union[PlainQuantity, PlainUnit]
+DimensionT = TypeVar("DimensionT", bound=Dimension)
+MeasurableT = TypeVar("MeasurableT", bound="Measurable")
+
+UnitRegistry = pint.UnitRegistry(cache_folder=":auto:", non_int_type=Decimal)
+
+class Measurable(Generic[DimensionT]):
+    """
+    A value that has operations to convert or derive it.
+    """
+
+    _wrappers: dict[type[Dimension], type["Measurable"]] = {}
+
+    @classmethod
+    def register_wrapper(cls, dimension: type[Dimension]) \
+            -> Callable[[type["Measurable"]], type["Measurable"]]:
+        """
+        Register a measurable type which can wrap a `pint` dimension type.
+        """
+
+        def decorator(subclass: type["Measurable"]) -> type["Measurable"]:
+            cls._wrappers[dimension] = subclass
+            return subclass
+
+        return decorator
+
+    def __init__(self, value: DimensionT) -> None:
+        super().__init__()
+        self.value = value
+
+    def _can_wrap(self, dimension: type[object]) -> TypeGuard[type[Dimension]]:
+        return dimension in self._wrappers
+
+    def _wrap(self, new: object) -> "Measurable":
+        dimension = type(new)
+        if self._can_wrap(dimension):
+            return self._wrappers[dimension](new)
+
+        raise TypeError("Could not convert to measurable object")
+
+    @staticmethod
+    def _unwrap(other: object) -> object:
+        if isinstance(other, Measurable):
+            return other.value
+        return other
+
+    def __lt__(self, other: object) -> bool:
+        return self.value < self._unwrap(other)
+
+    def __le__(self, other: object) -> bool:
+        return self.value <= self._unwrap(other)
+
+    def __eq__(self, other: object) -> bool:
+        return self.value == self._unwrap(other)
+
+    def __ne__(self, other: object) -> bool:
+        return self.value != self._unwrap(other)
+
+    def __gt__(self, other: object) -> bool:
+        return self.value > self._unwrap(other)
+
+    def __ge__(self, other: object) -> bool:
+        return self.value >= self._unwrap(other)
+
+    def __hash__(self) -> int:
+        return hash(self.value)
+
+    def __bool__(self) -> bool:
+        return bool(self.value)
+
+    def __mul__(self, other: object) -> "Measurable":
+        return self._wrap(self.value * self._unwrap(other))
+
+    def __truediv__(self: Self, other: object) -> "Measurable":
+        return self._wrap(self.value / self._unwrap(other))
+
+    __rmul__ = __mul__
+
+    def __rtruediv__(self, other: object) -> "Measurable":
+        return self._wrap(self._unwrap(other) / self.value)

--- a/rechu/types/measurable/decorator.py
+++ b/rechu/types/measurable/decorator.py
@@ -1,0 +1,42 @@
+"""
+Type decorators for measurable types.
+"""
+
+from sqlalchemy import String
+from .quantity import Quantity
+from .unit import Unit
+from ..decorator import SerializableType
+
+class QuantityType(SerializableType[Quantity, str]):
+    # pylint: disable=too-many-ancestors
+    """
+    Type decoration handler for quantities.
+    """
+
+    cache_ok = True
+    impl = String()
+
+    @property
+    def serializable_type(self) -> type[Quantity]:
+        return Quantity
+
+    @property
+    def serialized_type(self) -> type[str]:
+        return str
+
+class UnitType(SerializableType[Unit, str]):
+    # pylint: disable=too-many-ancestors
+    """
+    Type decoration handler for units.
+    """
+
+    cache_ok = True
+    impl = String()
+
+    @property
+    def serializable_type(self) -> type[Unit]:
+        return Unit
+
+    @property
+    def serialized_type(self) -> type[str]:
+        return str

--- a/rechu/types/measurable/quantity.py
+++ b/rechu/types/measurable/quantity.py
@@ -1,0 +1,111 @@
+"""
+Quantity type.
+"""
+
+from decimal import Decimal
+from typing import Optional, Union
+from pint.errors import UndefinedUnitError
+from pint.facets.plain import PlainQuantity
+from typing_extensions import Self
+from .base import Measurable, UnitRegistry
+from .unit import Unit, UnitNew
+
+QuantityNew = Union["Quantity", PlainQuantity, Decimal, float, str]
+
+@Measurable.register_wrapper(UnitRegistry.Quantity)
+class Quantity(Measurable[PlainQuantity]):
+    """
+    A quantity value with an optional dimension with original input preserved.
+    """
+
+    def __init__(self, value: QuantityNew, unit: UnitNew = None) -> None:
+        if isinstance(value, Quantity):
+            value = str(value)
+        elif isinstance(value, PlainQuantity) and value.dimensionless:
+            value = value.magnitude
+        if isinstance(unit, Unit):
+            unit = str(unit)
+        try:
+            super().__init__(UnitRegistry.Quantity(value, units=unit))
+        except UndefinedUnitError as error:
+            raise ValueError("Could not create a quantity with unit") from error
+        if unit is None or self.value.dimensionless:
+            self._original = str(value)
+        else:
+            self._original = f"{value}{unit}"
+
+    @property
+    def amount(self) -> float:
+        """
+        Retrieve the magnitude of the quantity as a plain number.
+        """
+
+        return self.value.magnitude
+
+    @property
+    def unit(self) -> Optional[Unit]:
+        """
+        Retrieve the normalized unit of the quantity, or `None` if it has no
+        unit dimensionality.
+        """
+
+        if self.value.dimensionless:
+            return None
+
+        return Unit(self.value.units)
+
+    def __repr__(self) -> str:
+        if self.value.dimensionless:
+            return f"Quantity({self._original!r})"
+
+        return f"Quantity('{self.amount!s}', '{self.value.units!s}')"
+
+    def __str__(self) -> str:
+        return self._original
+
+    def __int__(self) -> int:
+        return int(self.amount)
+
+    def __float__(self) -> float:
+        return float(self.amount)
+
+    def __add__(self: Self, other: object) -> Self:
+        return self.__class__(self.value + self._unwrap(other))
+
+    def __sub__(self: Self, other: object) -> Self:
+        return self.__class__(self.value - self._unwrap(other))
+
+    def __floordiv__(self: Self, other: object) -> Self:
+        return self.__class__(self.value // self._unwrap(other))
+
+    def __mod__(self: Self, other: object) -> Self:
+        return self.__class__(self.value % self._unwrap(other))
+
+    def __pow__(self: Self, other: object) -> Self:
+        return self.__class__(self.value ** self._unwrap(other))
+
+    __radd__ = __add__
+
+    def __rsub__(self: Self, other: object) -> Self:
+        return self.__class__(self._unwrap(other) - self.value)
+
+    def __rfloordiv__(self: Self, other: object) -> Self:
+        return self.__class__(self._unwrap(other) // self.value)
+
+    def __rmod__(self: Self, other: object) -> Self:
+        return self.__class__(self._unwrap(other) % self.value)
+
+    def __rpow__(self: Self, other: object) -> Self:
+        return self.__class__(self._unwrap(other) ** self.value)
+
+    def __neg__(self: Self) -> Self:
+        return self.__class__(-self.value)
+
+    def __pos__(self: Self) -> Self:
+        return self.__class__(+self.value)
+
+    def __abs__(self) -> Self:
+        return self.__class__(abs(self.value))
+
+    def __round__(self: Self, ndigits: Optional[int] = 0) -> Self:
+        return self.__class__(round(self.value, ndigits=ndigits))

--- a/rechu/types/measurable/unit.py
+++ b/rechu/types/measurable/unit.py
@@ -1,0 +1,31 @@
+"""
+Unit type.
+"""
+
+from typing import Optional, Union
+from pint.facets.plain import PlainUnit
+from .base import Measurable, UnitRegistry
+
+UnitNew = Optional[Union["Unit", PlainUnit, str]]
+
+@Measurable.register_wrapper(UnitRegistry.Unit)
+class Unit(Measurable[PlainUnit]):
+    """
+    A normalized unit value.
+    """
+
+    def __init__(self, unit: UnitNew) -> None:
+        if isinstance(unit, Unit):
+            unit = str(unit)
+        elif unit is None:
+            unit = ""
+        super().__init__(UnitRegistry.Unit(unit))
+
+    def __repr__(self) -> str:
+        return f"Unit('{self.value!s}')"
+
+    def __str__(self) -> str:
+        return str(self.value)
+
+    def __bool__(self) -> bool:
+        return not self.value.dimensionless

--- a/rechu/types/quantized.py
+++ b/rechu/types/quantized.py
@@ -1,0 +1,62 @@
+"""
+Attribute types for numeric values with discrete precision.
+"""
+
+from decimal import Decimal
+from typing import Union
+from sqlalchemy import BigInteger, Numeric
+from .decorator import SerializableType
+
+PriceNew = Union[Decimal, float, str]
+
+class GTIN(int):
+    """
+    Global trade item number identifier for products.
+    """
+
+class Price(Decimal):
+    """
+    Price type with scale of 2 (number of decimal places).
+    """
+
+    _quantize = Decimal('1.00')
+
+    def __new__(cls, value: PriceNew) -> "Price":
+        try:
+            return super().__new__(cls, Decimal(value).quantize(cls._quantize))
+        except ArithmeticError as e:
+            raise ValueError("Could not construct a two-decimal price") from e
+
+class GTINType(SerializableType[GTIN, int]):
+    # pylint: disable=too-many-ancestors
+    """
+    Type decoration handler for GTINs.
+    """
+
+    cache_ok = True
+    impl = BigInteger()
+
+    @property
+    def serializable_type(self) -> type[GTIN]:
+        return GTIN
+
+    @property
+    def serialized_type(self) -> type[int]:
+        return int
+
+class PriceType(SerializableType[Price, Decimal]):
+    # pylint: disable=too-many-ancestors
+    """
+    Type decoration handler for prices.
+    """
+
+    cache_ok = True
+    impl = Numeric(None, 2)
+
+    @property
+    def serializable_type(self) -> type[Price]:
+        return Price
+
+    @property
+    def serialized_type(self) -> type[Decimal]:
+        return Decimal

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 alembic==1.14.1
+Pint==0.24.4
 python-dateutil==2.9.0.post0
 PyYAML==6.0.2
 SQLAlchemy==2.0.36

--- a/samples/new/receipt_invalid_input
+++ b/samples/new/receipt_invalid_input
@@ -1,6 +1,7 @@
 2024-11-01 12:34
 inv
 foo
+1
 bar
 baz
 0.01
@@ -25,29 +26,53 @@ gtin
 label
 
 price
-0.01
+
 2024
 price
 0.02
 
 
+2
+xyz
+5.00
+10%
+label
+xyz
+discount
+rate
+weight
+
+1kg
+discount
+over
+
 0
+rate
+-0.50
+xyz
 disco
 -0.01
 ?
 h
-meta
-
-0
-meta
-
-?
 products
-baz
+8oz
 qux
 0.02
 bonus
+price
+442.10
+
 0
+meta
+label
+nothing
+
+0
+meta
+label
+nothing
+
+?
 meta
 brand
 No
@@ -55,6 +80,7 @@ gtin
 4321987654321
 
 
+meta
 portions
 9
 sku

--- a/samples/products-id.yml
+++ b/samples/products-id.yml
@@ -9,7 +9,7 @@ products:
   portions: 22
   weight: 150g
   gtin: 01234567890123
-- prices: [5.00, 7.50, 8.00]
+- prices: [2.00, 2.50, 3.00]
   bonuses: [disco]
   type: chocolate
   sku: abc123

--- a/tests/command/new/input.py
+++ b/tests/command/new/input.py
@@ -1,0 +1,133 @@
+"""
+Tests for input source of new subcommand.
+"""
+
+from datetime import datetime
+from io import StringIO
+import unittest
+from unittest.mock import patch
+from rechu.command.new import InputSource, Prompt
+from . import INPUT_MODULE
+
+class InputSourceTest(unittest.TestCase):
+    """
+    Tests for abstract base class of an input source.
+    """
+
+    def setUp(self) -> None:
+        self.input = InputSource()
+
+    def test_get_input(self) -> None:
+        """
+        Test retrieving an input.
+        """
+
+        with self.assertRaises(NotImplementedError):
+            self.input.get_input("foo", str, "test")
+
+    def test_get_date(self) -> None:
+        """
+        Test retrieving a date input.
+        """
+
+        with self.assertRaises(NotImplementedError):
+            self.input.get_date()
+
+    def test_get_output(self) -> None:
+        """
+        Test retrieving an output stream.
+        """
+
+        with self.assertRaises(NotImplementedError):
+            self.input.get_output()
+
+    def test_get_completion(self) -> None:
+        """
+        Test retrieving a completion option for the current suggestions.
+        """
+
+        with self.assertRaises(NotImplementedError):
+            self.input.get_completion("foo", 0)
+
+class PromptTest(unittest.TestCase):
+    """
+    Tests for standard input prompt.
+    """
+
+    def test_get_input(self) -> None:
+        """
+        Test retrieving an input.
+        """
+
+        prompt = Prompt()
+        with patch(f"{INPUT_MODULE}.input", return_value="foobar"):
+            self.assertEqual(prompt.get_input("foo", str), "foobar")
+        with patch(f"{INPUT_MODULE}.input", return_value="9.99"):
+            self.assertEqual(prompt.get_input("foo", float), 9.99)
+        with patch(f"{INPUT_MODULE}.input", return_value="10"):
+            self.assertEqual(prompt.get_input("foo", int), 10)
+        with patch(f"{INPUT_MODULE}.input", return_value=""):
+            self.assertEqual(prompt.get_input("foo", str), "")
+            self.assertEqual(prompt.get_input("foo", str, default="baz"), "baz")
+            self.assertEqual(prompt.get_input("foo", int, default=42), 42)
+
+    def test_get_date(self) -> None:
+        """
+        Test retrieving a date input.
+        """
+
+        prompt = Prompt()
+        date = datetime(2025, 6, 9, 0, 0, 0)
+        with patch(f"{INPUT_MODULE}.input", return_value="2025-06-09"):
+            self.assertEqual(prompt.get_date(), date)
+        with patch(f"{INPUT_MODULE}.input", return_value=""):
+            self.assertEqual(prompt.get_date(default=date), date)
+        with patch(f"{INPUT_MODULE}.input", return_value="12:34"):
+            default = datetime(2025, 6, 9, 3, 12, 0)
+            self.assertEqual(prompt.get_date(default=default),
+                             datetime(2025, 6, 9, 12, 34, 0))
+
+    def test_get_completion(self) -> None:
+        """
+        Test retrieving a completion option for the current suggestions.
+        """
+
+        prompt = Prompt()
+        self.assertIsNone(prompt.get_completion("foo", 0))
+
+        prompt.update_suggestions({"test": ["barbaz", "foobar", "foobaz"]})
+        with patch(f"{INPUT_MODULE}.input", return_value="foobar"):
+            prompt.get_input("qux", str, options="test")
+        self.assertEqual(prompt.get_completion("", 0), "barbaz")
+        self.assertEqual(prompt.get_completion("", 1), "foobar")
+        self.assertEqual(prompt.get_completion("", 2), "foobaz")
+        self.assertIsNone(prompt.get_completion("", 3))
+
+        self.assertEqual(prompt.get_completion("foo", 0), "foobar")
+        self.assertEqual(prompt.get_completion("foo", 1), "foobaz")
+        self.assertIsNone(prompt.get_completion("foo", 2))
+
+    @patch('sys.stdout', new_callable=StringIO)
+    def test_display_matches(self, stdout: StringIO) -> None:
+        """
+        Test displaying matches compatible with readline buffers.
+        """
+
+        prompt = Prompt()
+        prompt.display_matches("nothing", [], 0)
+        self.assertEqual(stdout.getvalue(), "\n> ")
+
+        stdout.seek(0)
+        stdout.truncate()
+
+        prompt.display_matches("foo", ["foobar", "foobaz"], 6)
+        self.assertEqual(stdout.getvalue(), "\nbar    baz    \n> ")
+
+        stdout.seek(0)
+        stdout.truncate()
+
+        prompt.display_matches("foo", [f"foo{'bar' * 27}", f"foo{'baz' * 27}"],
+                               86)
+        space = ' ' * 19
+        self.assertEqual(stdout.getvalue(),
+                         f"\n{'bar' * 27}{space}\n{'baz' * 27}{space}\n> ")

--- a/tests/command/new/step.py
+++ b/tests/command/new/step.py
@@ -1,0 +1,28 @@
+"""
+Tests for steps to create a receipt in new subcommand.
+"""
+
+import unittest
+from rechu.command.new import Prompt, Step
+from rechu.models.receipt import Receipt
+
+class StepTest(unittest.TestCase):
+    """
+    Tests for abstract base class of a receipt creation step.
+    """
+
+    def test_run(self):
+        """
+        Test performing the step.
+        """
+
+        with self.assertRaises(NotImplementedError):
+            Step(Receipt(), Prompt()).run()
+
+    def test_description(self):
+        """
+        Test retreiving a usage message of the step.
+        """
+
+        with self.assertRaises(NotImplementedError):
+            self.assertEqual(Step(Receipt(), Prompt()).description, "")

--- a/tests/models/base.py
+++ b/tests/models/base.py
@@ -2,12 +2,11 @@
 Tests for base model for receipt cataloging.
 """
 
-from decimal import Decimal
 from typing import cast
 import unittest
 from sqlalchemy import ForeignKey, Table
 from sqlalchemy.orm import Mapped, mapped_column
-from rechu.models.base import Base, Price
+from rechu.models.base import Base
 
 class TestEntity(Base): # pylint: disable=too-few-public-methods
     """
@@ -18,22 +17,6 @@ class TestEntity(Base): # pylint: disable=too-few-public-methods
 
     id: Mapped[int] = mapped_column(primary_key=True)
     other: Mapped[int] = mapped_column(ForeignKey('test.id'))
-
-class PriceTest(unittest.TestCase):
-    """
-    Tests for prices with scale of 2.
-    """
-
-    def test_init(self) -> None:
-        """
-        Test creating a new price.
-        """
-
-        self.assertEqual(str(Price('1')), '1.00')
-        self.assertEqual(str(Price(1.0)), '1.00')
-        self.assertEqual(str(Price(1.0001)), '1.00')
-        self.assertEqual(str(Price(1)), '1.00')
-        self.assertEqual(str(Price(Decimal('1.0'))), '1.00')
 
 class BaseTest(unittest.TestCase):
     """

--- a/tests/models/product.py
+++ b/tests/models/product.py
@@ -4,7 +4,7 @@ Tests for product metadata model.
 
 from itertools import zip_longest
 from typing import Optional
-from rechu.models.base import Price
+from rechu.models.base import Price, Quantity
 from rechu.models.product import Product, LabelMatch, PriceMatch, DiscountMatch
 from tests.database import DatabaseTestCase
 
@@ -32,8 +32,8 @@ class ProductTest(DatabaseTestCase):
                         discounts=[
                             DiscountMatch(label='one'), DiscountMatch(label='2')
                         ],
-                        weight='750g', volume='1l', alcohol='2.0%',
-                        sku='1234', gtin=1234567890123)
+                        weight=Quantity('750g'), volume=Quantity('1l'),
+                        alcohol='2.0%', sku='1234', gtin=1234567890123)
 
         self.assertTrue(product.merge(other))
 
@@ -57,8 +57,8 @@ class ProductTest(DatabaseTestCase):
         self.assertEqual(product.type, 'bar')
         self.assertEqual(product.portions, 12)
 
-        self.assertEqual(product.weight, '750g')
-        self.assertEqual(product.volume, '1l')
+        self.assertEqual(product.weight, Quantity('750g'))
+        self.assertEqual(product.volume, Quantity('1l'))
         self.assertEqual(product.alcohol, '2.0%')
         self.assertEqual(product.sku, '1234')
         self.assertEqual(product.gtin, 1234567890123)
@@ -114,8 +114,8 @@ class ProductTest(DatabaseTestCase):
 
         product = Product(shop='id', brand='abc', description='def',
                           category='foo', type='bar', portions=12,
-                          weight='750g', volume='1l', alcohol='2.0%',
-                          sku='1234', gtin=1234567890123)
+                          weight=Quantity('750g'), volume=Quantity('1l'),
+                          alcohol='2.0%', sku='1234', gtin=1234567890123)
         self.assertEqual(repr(product),
                          "Product(id=None, shop='id', labels=[], prices=[], "
                          "discounts=[], brand='abc', description='def', "
@@ -124,10 +124,14 @@ class ProductTest(DatabaseTestCase):
                          "sku='1234', gtin=1234567890123)")
         product.labels = [LabelMatch(product=product, name='label')]
         product.prices = [
-            PriceMatch(product=product, value=1.23, indicator='minimum'),
-            PriceMatch(product=product, value=7.89, indicator='maximum')
+            PriceMatch(product=product, value=Price('1.23'),
+                       indicator='minimum'),
+            PriceMatch(product=product, value=Price('7.89'),
+                       indicator='maximum')
         ]
         product.discounts = [DiscountMatch(product=product, label='disco')]
+        product.type = None
+        product.volume = None
         with self.database as session:
             session.add(product)
             session.flush()
@@ -135,6 +139,6 @@ class ProductTest(DatabaseTestCase):
                              "Product(id=1, shop='id', labels=['label'], "
                              "prices=[('minimum', 1.23), ('maximum', 7.89)], "
                              "discounts=['disco'], brand='abc', "
-                             "description='def', category='foo', type='bar', "
-                             "portions=12, weight='750g', volume='1l', "
+                             "description='def', category='foo', type=None, "
+                             "portions=12, weight='750g', volume=None, "
                              "alcohol='2.0%', sku='1234', gtin=1234567890123)")

--- a/tests/models/receipt.py
+++ b/tests/models/receipt.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import unittest
 from sqlalchemy import select
 from rechu.io.receipt import ReceiptReader
-from rechu.models.base import Price
+from rechu.models.base import Price, Quantity
 from rechu.models.product import Product
 from rechu.models.receipt import Receipt, ProductItem, Discount
 from tests.database import DatabaseTestCase
@@ -49,7 +49,7 @@ class ProductItemTest(DatabaseTestCase):
         Test the string representation of the model.
         """
 
-        self.assertEqual(repr(ProductItem(quantity='1', label='label',
+        self.assertEqual(repr(ProductItem(quantity=Quantity('1'), label='label',
                                           price=Price('0.99'),
                                           discount_indicator=None,
                                           position=0)),
@@ -60,8 +60,9 @@ class ProductItemTest(DatabaseTestCase):
         updated = datetime(2024, 11, 1, 12, 34, 0)
         receipt = Receipt(filename='file', updated=updated, date=updated.date(),
                           shop='id')
-        product = ProductItem(quantity='2', label='bulk', price=Price('5.00'),
-                              discount_indicator='bonus', position=0)
+        product = ProductItem(quantity=Quantity('2'), label='bulk',
+                              price=Price('5.00'), discount_indicator='bonus',
+                              position=0, amount=2, unit=None)
         receipt.products = [product]
         product.product = Product(shop='id', sku='1234')
         with self.database as session:
@@ -90,8 +91,9 @@ class DiscountTest(DatabaseTestCase):
         updated = datetime(2024, 11, 1, 12, 34, 0)
         receipt = Receipt(filename='file', updated=updated, date=updated.date(),
                           shop='id')
-        product = ProductItem(quantity='2', label='bulk', price=Price('5.00'),
-                              discount_indicator='bonus', position=0)
+        product = ProductItem(quantity=Quantity('2'), label='bulk',
+                              price=Price('5.00'), discount_indicator='bonus',
+                              position=0, amount=2, unit=None)
         discount = Discount(label='disco', price_decrease=Price('-2.00'),
                             items=[product], position=0)
         self.assertEqual(repr(discount),

--- a/tests/types/__init__.py
+++ b/tests/types/__init__.py
@@ -1,0 +1,3 @@
+"""
+Tests for attribute types of model properties.
+"""

--- a/tests/types/decorator.py
+++ b/tests/types/decorator.py
@@ -1,0 +1,76 @@
+"""
+Tests for type decorators of model type annotation maps.
+"""
+
+from typing import Generic
+import unittest
+from rechu.types.decorator import SerializableType, T, ST
+from rechu.types.measurable.base import Measurable
+from ..database import DatabaseTestCase
+
+class SerializableTypeTestCase(DatabaseTestCase, Generic[T, ST]):
+    """
+    Test case base class for type decoration handler of serializable values.
+    """
+
+    type_decorator: type[SerializableType] = SerializableType
+    value: T
+    representation: ST
+
+    def setUp(self) -> None:
+        super().setUp()
+        if self.__class__ is SerializableTypeTestCase and \
+            self._testMethodName != 'test_type':
+            raise unittest.SkipTest("Generic class is not tested")
+        self._type = self.type_decorator()
+
+    def test_process_literal_param(self) -> None:
+        """
+        Test retrieviing a literal parameter value.
+        """
+
+        dialect = self.database.engine.dialect
+        self.assertEqual(self._type.process_literal_param(None, dialect),
+                         "NULL")
+        if isinstance(self.representation, str):
+            representation = repr(self.representation)
+        else:
+            representation = str(self.representation)
+        self.assertEqual(self._type.process_literal_param(self.value, dialect),
+                         representation)
+
+    def test_process_bind_param(self) -> None:
+        """
+        Test retrieving a bound parameter value.
+        """
+
+        dialect = self.database.engine.dialect
+        self.assertIsNone(self._type.process_bind_param(None, dialect))
+        self.assertEqual(self._type.process_bind_param(self.value, dialect),
+                         self.representation)
+
+    def test_process_result_value(self) -> None:
+        """
+        Test retrieving a result row column value.
+        """
+
+        dialect = self.database.engine.dialect
+        self.assertIsNone(self._type.process_result_value(None, dialect))
+        self.assertEqual(self._type.process_result_value(self.representation,
+                                                         dialect), self.value)
+
+    def test_type(self) -> None:
+        """
+        Test retrieving the Python type.
+        """
+
+        if self.__class__ is SerializableTypeTestCase:
+            with self.assertRaises(NotImplementedError):
+                self.assertNotEqual(self._type.serializable_type, Measurable)
+            with self.assertRaises(NotImplementedError):
+                self.assertNotEqual(self._type.serialized_type, str)
+        else:
+            self.assertEqual(self._type.python_type, type(self.value))
+            self.assertEqual(self._type.serializable_type, type(self.value))
+            self.assertEqual(self._type.serialized_type,
+                             type(self.representation))

--- a/tests/types/measurable/__init__.py
+++ b/tests/types/measurable/__init__.py
@@ -1,0 +1,3 @@
+"""
+Tests for attribute types of measurable values such as quantities and units.
+"""

--- a/tests/types/measurable/base.py
+++ b/tests/types/measurable/base.py
@@ -1,0 +1,126 @@
+"""
+Tests for base type of measurable quantities and units.
+"""
+
+import operator
+from typing import Generic
+import unittest
+from pint.facets.plain import PlainQuantity
+from rechu.types.measurable.base import Measurable, MeasurableT
+
+class FakeQuantity(PlainQuantity):
+    """
+    Test quantity type.
+    """
+
+@Measurable.register_wrapper(FakeQuantity)
+class Measurement(Measurable[FakeQuantity]):
+    # pylint: disable=too-few-public-methods
+    """
+    Test measurable type which does not always properly wrap its dimensions.
+    """
+
+    def __add__(self, other: object) -> "Measurable":
+        result = self._unwrap(other) + self.value
+        if self.value.dimensionless:
+            return self._wrap(float(result))
+        return self._wrap(result)
+
+class MeasurableTestCase(unittest.TestCase, Generic[MeasurableT]):
+    """
+    Test case base class for measurable values.
+    """
+
+    value: MeasurableT
+    same: MeasurableT
+    bigger: MeasurableT
+    smaller: MeasurableT
+    empty: MeasurableT
+
+    def setUp(self) -> None:
+        super().setUp()
+        if self.__class__ is MeasurableTestCase and \
+            self._testMethodName != 'test_register_wrapper':
+            raise unittest.SkipTest("Generic class is not tested")
+
+    def test_register_wrapper(self) -> None:
+        """
+        Test registering a measurable type for wrapping and unwrapping purposes.
+        """
+
+        good = [FakeQuantity(4, 'kg'), FakeQuantity(2, 'kg')]
+        bad = [FakeQuantity(1.3), FakeQuantity(5)]
+        self.assertIsInstance(Measurement(good[0]) + Measurement(good[1]),
+                              Measurement)
+        with self.assertRaisesRegex(TypeError,
+                                    "Could not convert to measurable object"):
+            self.assertNotIsInstance(Measurement(bad[0]) + Measurement(bad[1]),
+                                     Measurement)
+
+    def test_eq(self) -> None:
+        """
+        Test the equality operator.
+        """
+
+        self.assertTrue(operator.eq(self.value, self.same))
+        self.assertFalse(operator.eq(self.value, self.bigger))
+
+    def test_ne(self) -> None:
+        """
+        Test the inquality operator.
+        """
+
+        self.assertTrue(operator.ne(self.value, self.bigger))
+        self.assertFalse(operator.ne(self.value, self.same))
+
+    def test_lt(self) -> None:
+        """
+        Test the less than operator.
+        """
+
+        self.assertTrue(operator.lt(self.value, self.bigger))
+        self.assertFalse(operator.lt(self.value, self.same))
+        self.assertFalse(operator.lt(self.value, self.smaller))
+
+    def test_le(self) -> None:
+        """
+        Test the less than or equals operator.
+        """
+
+        self.assertTrue(operator.le(self.value, self.bigger))
+        self.assertTrue(operator.le(self.value, self.same))
+        self.assertFalse(operator.le(self.value, self.smaller))
+
+    def test_gt(self) -> None:
+        """
+        Test the greater than operator.
+        """
+
+        self.assertTrue(operator.gt(self.value, self.smaller))
+        self.assertFalse(operator.gt(self.value, self.same))
+        self.assertFalse(operator.gt(self.value, self.bigger))
+
+    def test_ge(self) -> None:
+        """
+        Test the greater than or equals operator.
+        """
+
+        self.assertTrue(operator.ge(self.value, self.smaller))
+        self.assertTrue(operator.ge(self.value, self.same))
+        self.assertFalse(operator.ge(self.value, self.bigger))
+
+    def test_hash(self) -> None:
+        """
+        Test the hash function.
+        """
+
+        self.assertEqual(hash(self.value), hash(self.same))
+        self.assertNotEqual(hash(self.value), hash(self.bigger))
+
+    def test_bool(self) -> None:
+        """
+        Test the boolean operator.
+        """
+
+        self.assertTrue(bool(self.value))
+        self.assertFalse(bool(self.empty))

--- a/tests/types/measurable/decorator.py
+++ b/tests/types/measurable/decorator.py
@@ -1,0 +1,26 @@
+"""
+Tests for type decorators of measurable types.
+"""
+
+from rechu.types.measurable.decorator import QuantityType, UnitType
+from rechu.types.measurable.quantity import Quantity
+from rechu.types.measurable.unit import Unit
+from ..decorator import SerializableTypeTestCase
+
+class QuantityTypeTest(SerializableTypeTestCase[Quantity, str]):
+    """
+    Tests for type decoration handler of quantities.
+    """
+
+    type_decorator = QuantityType
+    value = Quantity("0.5kg")
+    representation = "0.5kg"
+
+class UnitTypeTest(SerializableTypeTestCase[Unit, str]):
+    """
+    Tests for type decoration handler of units.
+    """
+
+    type_decorator = UnitType
+    value = Unit("kg")
+    representation = "kilogram"

--- a/tests/types/measurable/quantity.py
+++ b/tests/types/measurable/quantity.py
@@ -1,0 +1,195 @@
+"""
+Tests for quantity type.
+"""
+
+from decimal import Decimal
+from rechu.types.measurable import Quantity, Unit
+from .base import MeasurableTestCase
+
+class QuantityTest(MeasurableTestCase[Quantity]):
+    """
+    Tests for quantity value with optional dimension and original input.
+    """
+
+    value = Quantity("1")
+    same = Quantity("1")
+    bigger = Quantity("2")
+    smaller = Quantity("0.50")
+    empty = Quantity(0)
+    dimensional = Quantity("1kg")
+
+    def test_amount(self) -> None:
+        """
+        Test retrieving the magnitude.
+        """
+
+        self.assertEqual(self.value.amount, 1.0)
+        self.assertEqual(self.smaller.amount, 0.5)
+        self.assertEqual(self.dimensional.amount, 1.0)
+
+    def test_unit(self) -> None:
+        """
+        Test retrieving the normalized unit of the quantity.
+        """
+
+        self.assertIsNone(self.value.unit)
+        self.assertEqual(self.dimensional.unit, Unit("kg"))
+
+    def test_repr(self) -> None:
+        """
+        Test the string representation of the value.
+        """
+
+        self.assertEqual(repr(self.value), "Quantity('1')")
+        self.assertEqual(repr(self.smaller), "Quantity('0.50')")
+        self.assertEqual(repr(self.empty), "Quantity('0')")
+        self.assertEqual(repr(self.dimensional), "Quantity('1', 'kilogram')")
+        self.assertEqual(repr(Quantity('1', unit=Unit(None))), "Quantity('1')")
+        self.assertEqual(repr(Quantity(self.smaller)), "Quantity('0.50')")
+
+    def test_str(self) -> None:
+        """
+        Test the string conversion of the value.
+        """
+
+        self.assertEqual(str(self.value), '1')
+        self.assertEqual(str(self.smaller), '0.50')
+        self.assertEqual(str(self.empty), '0')
+        self.assertEqual(str(self.dimensional), '1kg')
+        self.assertEqual(str(Quantity('1', unit=Unit(None))), '1')
+        self.assertEqual(str(self.value + self.bigger), '3')
+        # Arithmetic with units loses the original unit spelling for now.
+        self.assertEqual(str(self.dimensional * 5), '5 kilogram')
+        self.assertEqual(str(Quantity(self.dimensional)), '1kg')
+
+    def test_int(self) -> None:
+        """
+        Test the integer conversion of the value.
+        """
+
+        self.assertEqual(int(self.value), 1)
+        self.assertEqual(int(self.smaller), 0)
+        self.assertEqual(int(self.empty), 0)
+        self.assertEqual(int(self.dimensional), 1)
+
+    def test_float(self) -> None:
+        """
+        Test the floating point conversion of the value.
+        """
+
+        self.assertEqual(float(self.value), 1.0)
+        self.assertEqual(float(self.smaller), 0.5)
+        self.assertEqual(float(self.empty), 0.0)
+        self.assertEqual(float(self.dimensional), 1.0)
+
+    def test_add(self) -> None:
+        """
+        Test the addition operator.
+        """
+
+        self.assertEqual(self.value + self.same, Quantity('2'))
+        self.assertEqual(self.value + self.empty, self.value)
+        self.assertEqual(self.value + Decimal('0.75'), Quantity('1.75'))
+
+    def test_sub(self) -> None:
+        """
+        Test the subtraction operator.
+        """
+
+        self.assertEqual(self.value - self.same, self.empty)
+        self.assertEqual(self.value - self.empty, self.value)
+        self.assertEqual(self.value - self.smaller, self.smaller)
+        self.assertEqual(Decimal('1.25') - self.value, Quantity('0.25'))
+
+    def test_mul(self) -> None:
+        """
+        Test the multiplication operator.
+        """
+
+        self.assertEqual(self.value * self.same, self.value)
+        self.assertEqual(self.value * self.bigger, self.bigger)
+        self.assertEqual(self.smaller * self.bigger, self.value)
+        self.assertEqual(Decimal('0.5') * self.value, self.smaller)
+        self.assertEqual(self.dimensional * Quantity("2kg"), Quantity("2kg**2"))
+
+    def test_truediv(self) -> None:
+        """
+        Test the true division operator.
+        """
+
+        self.assertEqual(self.value / self.same, self.value)
+        self.assertEqual(self.value / self.bigger, self.smaller)
+        self.assertEqual(self.dimensional / self.bigger, Quantity("0.5kg"))
+        self.assertEqual(self.dimensional / Quantity("4kg"), Quantity("0.25"))
+        self.assertEqual(1 / self.smaller, Quantity('2'))
+
+    def test_floordiv(self) -> None:
+        """
+        Test the floor division operator.
+        """
+
+        self.assertEqual(self.value // self.same, self.value)
+        self.assertEqual(self.value // self.bigger, self.empty)
+        self.assertEqual(self.dimensional // Quantity("0.5kg"), self.bigger)
+        self.assertEqual(7 // self.bigger, Quantity("3"))
+
+    def test_mod(self) -> None:
+        """
+        Test the modulo operator.
+        """
+
+        self.assertEqual(self.value % self.bigger, self.value)
+        self.assertEqual(self.bigger % self.value, self.empty)
+        self.assertEqual(self.dimensional % Quantity("2kg"), self.dimensional)
+        self.assertEqual(10 % self.bigger, self.empty)
+
+    def test_pow(self) -> None:
+        """
+        Test the power operator.
+        """
+
+        self.assertEqual(self.value ** self.bigger, self.value)
+        self.assertEqual(self.smaller ** self.bigger, Quantity('0.25'))
+        self.assertEqual(5 ** self.bigger, Quantity('25'))
+        self.assertEqual(self.dimensional ** self.bigger, Quantity("1kg**2"))
+
+    def test_neg(self) -> None:
+        """
+        Test the negation operator.
+        """
+
+        self.assertEqual(-self.value, Quantity("-1"))
+        self.assertEqual(-self.empty, self.empty)
+        self.assertEqual(-self.dimensional, Quantity("-1kg"))
+
+    def test_pos(self) -> None:
+        """
+        Test the positive operator.
+        """
+
+        self.assertEqual(+self.value, self.value)
+        self.assertEqual(+self.dimensional, self.dimensional)
+
+    def test_abs(self) -> None:
+        """
+        Test the absolute operator.
+        """
+
+        self.assertEqual(abs(self.value), self.value)
+        self.assertEqual(abs(Quantity("-0.5")), self.smaller)
+        self.assertEqual(abs(self.dimensional), self.dimensional)
+
+    def test_round(self) -> None:
+        """
+        Test the rounding operator.
+        """
+
+        tests = [
+            (round(self.value), self.value),
+            (round(self.smaller), self.empty),
+            (round(self.smaller, 1), self.smaller),
+            (round(self.dimensional), self.dimensional)
+        ]
+        for rounded, target in tests:
+            with self.subTest(rounded=rounded):
+                self.assertEqual(rounded, target)

--- a/tests/types/measurable/unit.py
+++ b/tests/types/measurable/unit.py
@@ -1,0 +1,54 @@
+"""
+Tests for unit type.
+"""
+
+from rechu.types.measurable import Quantity, Unit
+from .base import MeasurableTestCase
+
+class UnitTest(MeasurableTestCase[Unit]):
+    """
+    Tests for normalized unit value.
+    """
+
+    value = Unit("g")
+    same = Unit("g")
+    bigger = Unit("kg")
+    smaller = Unit("mg")
+    empty = Unit(None)
+
+    def test_mul(self) -> None:
+        """
+        Test the multiplication operator.
+        """
+
+        self.assertEqual(self.value * self.same, Unit("g ** 2"))
+        self.assertNotEqual(self.value * self.bigger, Unit("g ** 2"))
+        self.assertEqual(1 * self.value, Quantity(1, "g"))
+
+    def test_truediv(self) -> None:
+        """
+        Test the true division operator.
+        """
+
+        self.assertEqual(self.value / self.same, self.empty)
+        self.assertEqual(1 / self.value, Quantity(1, "1 / g"))
+
+    def test_repr(self) -> None:
+        """
+        Test the string representation of the value.
+        """
+
+        self.assertEqual(repr(self.value), "Unit('gram')")
+        self.assertEqual(repr(self.empty), "Unit('dimensionless')")
+        self.assertEqual(repr(self.bigger), "Unit('kilogram')")
+        self.assertEqual(repr(Unit(self.empty)), "Unit('dimensionless')")
+
+    def test_str(self) -> None:
+        """
+        Test the string conversion of the value.
+        """
+
+        self.assertEqual(str(self.value), "gram")
+        self.assertEqual(str(self.empty), "dimensionless")
+        self.assertEqual(str(self.bigger), "kilogram")
+        self.assertEqual(str(Unit(self.empty)), "dimensionless")

--- a/tests/types/quantized.py
+++ b/tests/types/quantized.py
@@ -1,0 +1,44 @@
+"""
+Tests for attribute types of numeric values with discrete precision.
+"""
+
+from decimal import Decimal
+import unittest
+from rechu.types.quantized import GTIN, Price, GTINType, PriceType
+from .decorator import SerializableTypeTestCase
+
+class PriceTest(unittest.TestCase):
+    """
+    Tests for prices with scale of 2.
+    """
+
+    def test_init(self) -> None:
+        """
+        Test creating a new price.
+        """
+
+        self.assertEqual(str(Price('1')), '1.00')
+        self.assertEqual(str(Price(1.0)), '1.00')
+        self.assertEqual(str(Price(1.0001)), '1.00')
+        self.assertEqual(str(Price(1)), '1.00')
+        self.assertEqual(str(Price(Decimal('1.0'))), '1.00')
+        with self.assertRaisesRegex(ValueError, 'Could not construct .* price'):
+            self.assertNotEqual(str(Price('?')), '?')
+
+class GTINTypeTest(SerializableTypeTestCase[GTIN, int]):
+    """
+    Tests for type decoration handler of GTINs.
+    """
+
+    type_decorator = GTINType
+    value = GTIN(1234567890123)
+    representation = 1234567890123
+
+class PriceTypeTest(SerializableTypeTestCase[Price, Decimal]):
+    """
+    Tests for type decoration handler of prices.
+    """
+
+    type_decorator = PriceType
+    value = Price("1.00")
+    representation = Decimal("1.00")


### PR DESCRIPTION
- Use wrapper around pint library for quantities and units to provide all arithmetic but also retain original spelling of quantity, except when arithmetic is performed with units. Dimensionless units is hidden away, instead the quantity is shown as having no units.
- Product metadata price matchers will now compare its price with the receipt product item's price divided by the amount of the product, if possible: for quantities with units, the indicator field must have the normalized unit
- Validate quantity during new receipt creation
- Add database fields for extracted quantity amount and normalized unit
- Quantity, unit, price and GTIN fields now are properly presented as their type when a model is retrieved from the database, reducing the need to wrap them in their own constructor again
- Test database migration using data
- Disable foreign keys for SQLite during online migration because batch operations sometimes drop tables to recreate them causing foreign key constraint violations
- Update earlier migrations for GTIN size and shop keys to update data
- Clean up price matcher representation for simplicity and alignment with other model representation of prices
- Add product units to suggestion options for price indicator of metadata price matcher and correct discount suggestion for meta key
- Make weight and volume fields of product metadata quantity type
- New: Read prices and quantities (metadata values only) as their type instead of possibly casting them later on, to improve flow of validating values and avoiding rounding errors. Receipt product item quantity input is still initially read as string to allow menu/meta input.
- Matcher for discount now accepts if just one discount label matches, instead of all the receipt product items matching a metadata label.
- New: Allow skipping precise discount match during pre-discount step
- Perform candidate matching with all products after creating a product metadata model and skip if it matches the product as a duplicate, for example from a concurrent database write
- Skip product meta creation step if all items have been matched
- Improve logging of matched metadata (also when there are duplicates or when we exclude matching on discounts)
- Simplify product meta tracking to provide all products during matching
- Mention how many products have been matched on the receipt
- Stop asking for metadata if empty key provided without any metadata
- Add default values for receipt date input (current day), product meta price matcher indicator (unit of current item) and other meta fields, adding prompt information about empty input
- Show date suggestions for receipt date input, update suggestions for price matcher indicators once a receipt is (partially) filled and add suggestions for brand, category and type meta fields
- Do not automatically run the first step in the menu (read) when choice is an empty string
