### PR TITLE
Product inventory: Only use shared fields if set, not in new view step

### DIFF
--- a/rechu/command/new/step.py
+++ b/rechu/command/new/step.py
@@ -611,7 +611,8 @@ class View(Step):
         if self._products:
             print(file=output)
             print("New product metadata:", file=output)
-            products = ProductsWriter(Path("products.yml"), self._products)
+            products = ProductsWriter(Path("products.yml"), self._products,
+                                      shared_fields=('shop',))
             products.serialize(output)
 
         return {}
@@ -707,8 +708,7 @@ class Write(Step):
                 inventory = ProductInventory.select(session)
                 updates = ProductInventory.spread(self._products)
                 logging.warning('%r %r', updates, self._products)
-                for path, products in inventory.merge_update(updates).items():
-                    ProductsWriter(path, products).write()
+                inventory.merge_update(updates).write()
 
             session.add(self._receipt)
 

--- a/rechu/inventory/base.py
+++ b/rechu/inventory/base.py
@@ -2,10 +2,11 @@
 Bag of files containing multiple grouped models that share common properties.
 """
 
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable, Iterator, Sequence
 from pathlib import Path
 from typing import Mapping, Optional, TypeVar
 from sqlalchemy.orm import Session
+from ..io.base import Writer
 from ..models.base import Base as ModelBase
 
 T = TypeVar('T', bound=ModelBase)
@@ -43,6 +44,21 @@ class Inventory(Mapping[Path, Sequence[T]]):
         """
 
         raise NotImplementedError('Reading must be implemented by subclass')
+
+    def get_writers(self) -> Iterator[Writer[T]]:
+        """
+        Obtain writers for each inventory file.
+        """
+
+        raise NotImplementedError('Writers must be implemented by subclass')
+
+    def write(self) -> None:
+        """
+        Write an inventory to files.
+        """
+
+        for writer in self.get_writers():
+            writer.write()
 
     def merge_update(self, other: "Inventory[T]") -> "Inventory[T]":
         """

--- a/rechu/io/base.py
+++ b/rechu/io/base.py
@@ -26,6 +26,14 @@ class Reader(Generic[T], metaclass=ABCMeta):
         self._path = path
         self._updated = updated
 
+    @property
+    def path(self) -> Path:
+        """
+        Retrieve the path from which to read the models.
+        """
+
+        return self._path
+
     def read(self) -> Iterator[T]:
         """
         Read the file from the path and yield specific models from it.
@@ -66,6 +74,14 @@ class Writer(Generic[T], metaclass=ABCMeta):
         self._path = path
         self._models = models
         self._updated = updated
+
+    @property
+    def path(self) -> Path:
+        """
+        Retrieve the path to which to write the models.
+        """
+
+        return self._path
 
     def write(self) -> None:
         """

--- a/tests/inventory/base.py
+++ b/tests/inventory/base.py
@@ -42,6 +42,22 @@ class InventoryTest(unittest.TestCase):
         with self.assertRaises(NotImplementedError):
             Inventory.read()
 
+    def test_get_writers(self) -> None:
+        """
+        Test obtaining writers for each inventory file.
+        """
+
+        with self.assertRaises(NotImplementedError):
+            TestInventory().write()
+
+    def test_write(self) -> None:
+        """
+        Test writing an inventory to files.
+        """
+
+        with self.assertRaises(NotImplementedError):
+            TestInventory().write()
+
     def test_merge_update(self) -> None:
         """
         Test finding groups with models that are added or updated in another

--- a/tests/io/base.py
+++ b/tests/io/base.py
@@ -14,6 +14,14 @@ class ReaderTest(unittest.TestCase):
     Tests for file reader.
     """
 
+    def test_path(self) -> None:
+        """
+        Test retrieving the path from which to read the models.
+        """
+
+        self.assertEqual(Reader(Path('samples/receipt.yml')).path,
+                         Path('samples/receipt.yml'))
+
     def test_read(self) -> None:
         """
         Test reading the file from the path and yielding models.
@@ -34,6 +42,14 @@ class WriterTest(unittest.TestCase):
     """
     Tests for file writer.
     """
+
+    def test_path(self) -> None:
+        """
+        Test retrieving the path to which to write the models.
+        """
+
+        self.assertEqual(Writer(Path('samples/receipt.yml'), (Base(),)).path,
+                         Path('samples/receipt.yml'))
 
     def test_write(self) -> None:
         """

--- a/tests/io/products.py
+++ b/tests/io/products.py
@@ -226,6 +226,30 @@ class ProductsWriterTest(unittest.TestCase):
         actual = yaml.safe_load('\n'.join(file.readlines()))
         self.assertEqual(actual['type'], 'foo')
 
+    def test_serialize_common_not_shared(self) -> None:
+        """
+        Test writing a serialized variant of models with common attributes but
+        no shared fields to an open file.
+        """
+
+        for model in self.models:
+            model.type = 'foo'
+
+        # If the common attribute is not in the shared fields, then it is added
+        # to the models themselves.
+        writer = ProductsWriter(self.path, self.models, shared_fields=())
+        file = StringIO()
+        writer.serialize(file)
+
+        file.seek(0)
+        actual = yaml.safe_load('\n'.join(file.readlines()))
+        self.assertNotIn('shop', actual)
+        self.assertNotIn('type', actual)
+        for index, product in enumerate(actual['products']):
+            with self.subTest(index=index):
+                self.assertEqual(product['shop'], 'id')
+                self.assertEqual(product['type'], 'foo')
+
     def test_serialize_invalid(self) -> None:
         """
         Test writing a serialized variant of invalid models to an open file.


### PR DESCRIPTION
This makes the view step show the full product metadata in each object (aside from the shop), instead of category and type being placed in the common fields (even if these were not part of the pattern fields) when there are few products. This also applies to the YAML files without the pattern fields, to keep the portability of the file in case manual edits are made later on.