### PR TITLE
Read: Delete product metadata from DB that are no longer in YAML files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and we adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Read and new commands keep product metadata in sync between YAML files and 
+  database inventories, thus they delete stale database entities as well.
 - Prices of products on receipts are compared against prices in product 
   metadata after dividing the former by the amount of the item, if possible; 
   for quantities with units, the product item must have the normalized unit.

--- a/README.md
+++ b/README.md
@@ -49,12 +49,12 @@ using `[tool.rechu...]` sections.
 
 To create the database schema in the database path defined in the settings, use 
 `rechu create`. Then, you can create receipts and products with `rechu new`; 
-this commond writes the new receipts and product metadata both to YAML files in 
-the defined path/filename format and imports them to the database. You can also 
-bulk-import YAML files for receipts and product inventories from the defined 
-path, receipt subdirectory pattern and product pattern with `rechu read`; you 
-can later use the same command to synchronize changes in YAML files to the 
-database.
+this command writes the new receipts and product metadata to YAML files in the 
+defined path/filename format and imports them to the database, keeping both in 
+sync. You can also bulk-import YAML files for receipts and product inventories 
+from the defined path, receipt subdirectory pattern and product pattern with 
+`rechu read`; you can later use the same command to synchronize changes in YAML 
+files to the database.
 
 When you install a new version of this package, there may be database schema 
 changes which need to be applied to continue using the current model. After 

--- a/docs/source/commands.md
+++ b/docs/source/commands.md
@@ -110,9 +110,11 @@ import them into the database, then `rechu read` will read those files from the
 data path (specifically receipt files in subdirectories matching the data 
 pattern and data format settings as well as product inventories matching the 
 data products setting). Any existing entries corresponding with the filenames 
-are updated with changes in the YAML file, while files that have missing 
-entries are created in the database. This is a bulk method of synchronizing the 
-database with the YAML files.
+are updated with changes in the YAML file. Additionally, files that have 
+entries that are missing in the database are created there, and product 
+metadata no longer in the YAML inventories is deleted from the database. This 
+is a bulk method of synchronizing the database with the YAML files. For 
+deleting receipts, see the [delete](#delete) command.
 
 (delete)=
 ## Delete entries

--- a/rechu/command/new/__init__.py
+++ b/rechu/command/new/__init__.py
@@ -119,7 +119,6 @@ class New(Base):
         matcher.discounts = False
 
         with Database() as session:
-            matcher.load_map(session)
             self._load_suggestions(session, input_source)
 
         receipt_date = input_source.get_date(datetime.combine(date.today(),

--- a/rechu/inventory/base.py
+++ b/rechu/inventory/base.py
@@ -60,12 +60,19 @@ class Inventory(Mapping[Path, Sequence[T]]):
         for writer in self.get_writers():
             writer.write()
 
-    def merge_update(self, other: "Inventory[T]") -> "Inventory[T]":
+    def merge_update(self, other: "Inventory[T]", update: bool = True,
+                     only_new: bool = False) -> "Inventory[T]":
         """
         Find groups with models that are added or updated in the other inventory
         compared to the current inventory. The returned inventory contains the
         new, existing and merged models grouped by path; only paths with changes
         are included. The products in the current inventory are updated as well.
+        If `update` is enabled, then new models are added to and changed models
+        updated in the current inventory; this is the default. If `update` is
+        disabled, then the updated models are only provided in the return value,
+        the current object remains immutable. If `only_new` is enabled, then
+        models that existed but had changes are not considered, just like
+        unchanged models; `only_new` inherently disables `update`.
         """
 
         raise NotImplementedError('Merging must be implemented by subclass')

--- a/tests/command/new/__init__.py
+++ b/tests/command/new/__init__.py
@@ -179,6 +179,28 @@ class NewTest(DatabaseTestCase):
                                            unmatched_products,
                                            check_product_inventory=False)
 
+    def test_run_stale_product_meta(self) -> None:
+        """
+        Test executing the command with additional product metadata models
+        stored in the database, which are deleted once they are found to not
+        be in the file-based inventory.
+        """
+
+        # Preload the products and add another model
+        with self.database as session:
+            session.add_all(deepcopy(self.products))
+            session.add(Product(shop='id',
+                                labels=[LabelMatch(name='unmatched')],
+                                prices=[PriceMatch(value=Price('9.87'))],
+                                sku='zz123',
+                                gtin=5555555555555))
+
+        with self._setup_input(Path("samples/new/receipt_input")):
+            command = New()
+            command.run()
+            self._compare_expected_receipt(self.create, self.expected,
+                                           self.expected_products)
+
     def test_run_edit_clear(self) -> None:
         """
         Test executing the command with an edit in between that clears the file.

--- a/tests/command/read.py
+++ b/tests/command/read.py
@@ -21,8 +21,42 @@ class ReadTest(DatabaseTestCase):
     Test reading the YAML files and importing them to the database.
     """
 
+    # Number of products in samples/products-id.yml
+    product_count = 3
+
     # Overrides file sorted after samples/products-id.yml
     extra_products = Path("samples/products-id.zzz.yml")
+
+    # Extra products/overrides
+    extra = {
+        'shop': 'id',
+        'products': [
+            # Updates to existing products (overrides)
+            {
+                'labels': ['weigh'],
+                'description': 'Each product has different proportions'
+            },
+            {
+                'gtin': 1234567890123,
+                'portions': 21,
+                'prices': {
+                    'minimum': 0.89,
+                    'maximum': 1.09
+                }
+            },
+            {
+                'sku': 'abc123',
+                'prices': [8.00],
+                'brand': 'A Big Bar of Chocolate'
+            },
+            # New product separate from the one before
+            {
+                'bonuses': ['disco'],
+                'type': 'caramel'
+            }
+        ]
+    }
+
     min_price = Price('1.00')
 
     def tearDown(self) -> None:
@@ -33,6 +67,7 @@ class ReadTest(DatabaseTestCase):
         receipt = session.scalar(select(Receipt).limit(1))
         if receipt is None:
             self.fail("Expected receipt to be stored")
+        self.assertEqual(receipt.filename, 'receipt.yml')
         return receipt
 
     def _alter_price(self, value: Union[float, str]) -> Price:
@@ -53,28 +88,25 @@ class ReadTest(DatabaseTestCase):
         command = Read()
         command.run()
 
-        product_count = 3
-
         with self.database as session:
-            self.assertEqual(len(session.scalars(select(Product)).all()),
-                             product_count)
+            products = session.scalars(select(Product)).all()
+            self.assertEqual(len(products), self.product_count)
             receipt = self._get_receipt(session)
-            self.assertEqual(receipt.filename, 'receipt.yml')
             updated = receipt.updated
 
             self.assertIsNone(receipt.products[0].product,
                               f"Unexpected match for {receipt.products[0]!r}")
-            self.assertIsNotNone(receipt.products[1].product,
-                                 f"Expected match for {receipt.products[1]!r}")
+            self.assertEqual(receipt.products[1].product,
+                             products[self.product_count - 1],
+                             f"Expected match for {receipt.products[1]!r}")
 
         # Nothing happens if the directory is not updated.
         command.run()
 
         with self.database as session:
             self.assertEqual(len(session.scalars(select(Product)).all()),
-                             product_count)
+                             self.product_count)
             receipt = self._get_receipt(session)
-            self.assertEqual(receipt.filename, 'receipt.yml')
             self.assertEqual(receipt.updated, updated)
 
         os.utime('samples', times=(now + 1, now + 1))
@@ -88,41 +120,12 @@ class ReadTest(DatabaseTestCase):
 
         with self.database as session:
             self.assertEqual(len(session.scalars(select(Product)).all()),
-                             product_count)
+                             self.product_count)
             receipt = self._get_receipt(session)
-            self.assertEqual(receipt.filename, 'receipt.yml')
             self.assertEqual(receipt.updated, updated)
 
         with self.extra_products.open('w', encoding='utf-8') as extra_file:
-            extra = {
-                'shop': 'id',
-                'products': [
-                    # Updates to existing products (overrides)
-                    {
-                        'labels': ['weigh'],
-                        'description': 'Each product has different proportions'
-                    },
-                    {
-                        'gtin': 1234567890123,
-                        'portions': 21,
-                        'prices': {
-                            'minimum': 0.89,
-                            'maximum': 1.09
-                        }
-                    },
-                    {
-                        'sku': 'abc123',
-                        'prices': [8.00],
-                        'brand': 'A Big Bar of Chocolate'
-                    },
-                    # New product separate from the one before
-                    {
-                        'bonuses': ['disco'],
-                        'type': 'caramel'
-                    }
-                ]
-            }
-            yaml.dump(extra, extra_file)
+            yaml.dump(self.extra, extra_file)
 
         os.utime('samples/receipt.yml', times=(now + 1, now + 1))
         with patch('rechu.io.receipt.Price', side_effect=self._alter_price):
@@ -130,12 +133,13 @@ class ReadTest(DatabaseTestCase):
 
         with self.database as session:
             products = session.scalars(select(Product)).all()
-            self.assertEqual(len(products), product_count + 1)
-            self.assertEqual(products[-2].prices[0].value, Price('8.00'))
-            self.assertEqual(products[-2].brand, 'A Big Bar of Chocolate')
-            self.assertEqual(products[-1].type, 'caramel')
+            self.assertEqual(len(products), self.product_count + 1)
+            self.assertEqual(products[self.product_count - 1].prices[0].value,
+                             Price('8.00'))
+            self.assertEqual(products[self.product_count - 1].brand,
+                             'A Big Bar of Chocolate')
+            self.assertEqual(products[self.product_count].type, 'caramel')
             receipt = self._get_receipt(session)
-            self.assertEqual(receipt.filename, 'receipt.yml')
             self.assertNotEqual(receipt.updated, updated)
 
             # Changes to some receipt items do not cause them to be reordered
@@ -143,5 +147,18 @@ class ReadTest(DatabaseTestCase):
                              [Price('1.99'), Price('5.00'), Price('7.50'),
                               Price('8.00'), Price('2.50'), Price('1.89')])
 
-            self.assertEqual(receipt.products[1].product, products[-1],
+            self.assertEqual(receipt.products[1].product,
+                             products[self.product_count],
+                             f"Expected change {receipt.products[1]!r}")
+
+        self.extra_products.unlink(missing_ok=True)
+        command.run()
+
+        with self.database as session:
+            products = session.scalars(select(Product)).all()
+            self.assertEqual(len(products), self.product_count)
+            self.assertIsNone(products[self.product_count - 1].brand)
+            receipt = self._get_receipt(session)
+            self.assertEqual(receipt.products[1].product,
+                             products[self.product_count - 1],
                              f"Expected change {receipt.products[1]!r}")

--- a/tests/matcher/product.py
+++ b/tests/matcher/product.py
@@ -31,9 +31,9 @@ class ProductMatcherTest(DatabaseTestCase):
                       sku='abc123',
                       gtin=1234567890123)
 
-    def _test_samples(self, session: Session, insert_products: bool = True,
+    def _load_samples(self, session: Session, insert_products: bool = True,
                       insert_receipt: bool = True) \
-            -> tuple[list[Product], list[ProductItem]]:
+            -> tuple[list[Product], Receipt]:
         receipt = next(ReceiptReader(Path("samples/receipt.yml")).read())
         products = list(ProductsReader(Path("samples/products-id.yml")).read())
         if insert_products:
@@ -41,6 +41,14 @@ class ProductMatcherTest(DatabaseTestCase):
         if insert_receipt:
             session.add(receipt)
             session.flush()
+        return products, receipt
+
+    def _test_samples(self, session: Session, insert_products: bool = True,
+                      insert_receipt: bool = True) \
+            -> tuple[list[Product], list[ProductItem]]:
+        products, receipt = self._load_samples(session,
+                                               insert_products=insert_products,
+                                               insert_receipt=insert_receipt)
         items = receipt.products
 
         matcher = ProductMatcher()
@@ -264,6 +272,7 @@ class ProductMatcherTest(DatabaseTestCase):
 
         # No exception raised
         with self.database as session:
+            self._load_samples(session, insert_receipt=False)
             ProductMatcher().load_map(session)
 
     def test_add_map(self) -> None:


### PR DESCRIPTION
Synchronize the product inventory to avoid keeping old product metadata that might have been removed from the YAML file or was replaced with different matchers/identifiers, so they should no longer be used to match current or later receipt items.