### PR TITLE
Write complete product metadata inventories

### DIFF
--- a/rechu/command/read.py
+++ b/rechu/command/read.py
@@ -62,18 +62,17 @@ class Read(Base):
 
         for path in sorted(data_path.glob(products_glob)):
             logging.warning('Looking at products in %s', path)
-            with path.open('r', encoding='utf-8') as file:
-                try:
-                    for product in ProductsReader(path).parse(file):
-                        existing = matcher.check_map(product)
-                        if existing is None:
-                            session.add(product)
-                        else:
-                            product.id = existing.id
-                            unseen.discard(existing)
-                            session.merge(product)
-                except (TypeError, ValueError):
-                    logging.exception('Could not parse product from %s', path)
+            try:
+                for product in ProductsReader(path).read():
+                    existing = matcher.check_map(product)
+                    if existing is None:
+                        session.add(product)
+                    else:
+                        product.id = existing.id
+                        unseen.discard(existing)
+                        session.merge(product)
+            except (TypeError, ValueError):
+                logging.exception('Could not parse product from %s', path)
 
         for removed in unseen:
             logging.warning('Deleting %r from database', removed)

--- a/rechu/inventory/base.py
+++ b/rechu/inventory/base.py
@@ -69,9 +69,9 @@ class Inventory(Mapping[Path, Sequence[T]]):
         are included. The products in the current inventory are updated as well.
         If `update` is enabled, then new models are added to and changed models
         updated in the current inventory; this is the default. If `update` is
-        disabled, then the updated models are only provided in the return value,
-        the current object remains immutable. If `only_new` is enabled, then
-        models that existed but had changes are not considered, just like
+        disabled, then only the updated models are provided in the return value
+        and the current object also remains immutable. If `only_new` is enabled,
+        then models that existed but had changes are not considered, just like
         unchanged models; `only_new` inherently disables `update`.
         """
 

--- a/rechu/inventory/products.py
+++ b/rechu/inventory/products.py
@@ -101,12 +101,11 @@ class Products(dict, Inventory[Product]):
         _, glob_pattern, parts, _ = cls.get_parts(settings)
         for path in sorted(data_path.glob(glob_pattern)):
             logging.warning('Looking at products in %s', path)
-            with path.open('r', encoding='utf-8') as file:
-                try:
-                    products = list(ProductsReader(path).parse(file))
-                    inventory[path.resolve()] = products
-                except (TypeError, ValueError):
-                    logging.exception('Could not parse product from %s', path)
+            try:
+                products = list(ProductsReader(path).read())
+                inventory[path.resolve()] = products
+            except (TypeError, ValueError):
+                logging.exception('Could not parse product from %s', path)
 
         return cls(inventory, parts=parts)
 

--- a/rechu/inventory/products.py
+++ b/rechu/inventory/products.py
@@ -148,11 +148,13 @@ class Products(dict, Inventory[Product]):
                 if match is not None:
                     updates.append(match)
 
-            if changed:
-                updated[path] = updates
             if update:
                 self.setdefault(path, [])
                 self[path].extend(change for change in updates
                                   if change not in self[path])
+                # Make the updates follow the same order and have entire path
+                updates = self[path].copy()
+            if changed:
+                updated[path] = updates
 
         return Products(updated, parts=self._parts)

--- a/tests/inventory/products.py
+++ b/tests/inventory/products.py
@@ -253,6 +253,29 @@ class ProductsTest(DatabaseTestCase):
                                              {'gtin': 1234567890123})
         })
 
+    def test_merge_update_partial(self) -> None:
+        """
+        Test finding groups of products that are added or updated in another
+        inventory, which does not hold all the original products.
+        """
+
+        updated = self.inventory.merge_update(Products({
+            path: items[1:] if index >= 1 else items[:-1]
+            for index, (path, items) in enumerate(self.other.items())
+        }))
+        # Only updated paths are included, holding the full updated inventory.
+        self._check_inventory(updated, {
+            './samples/products-other.yml': ({'sku': 'ghi789'},
+                                             {'gtin': 1234567890123})
+        })
+        # The inventory itself was also updated with the new addition.
+        self._check_inventory(self.inventory, {
+            './samples/products-id.yml': ({'sku': 'abc123'},
+                                          {'sku': 'def456', 'type': 'foo'}),
+            './samples/products-other.yml': ({'sku': 'ghi789'},
+                                             {'gtin': 1234567890123})
+        })
+
     def test_merge_update_no_update(self) -> None:
         """
         Test finding groups of products that are added or changed in another


### PR DESCRIPTION
Even if only some products are added/updated, then we do not want to remove the other entries. Correct regression in inventory merge update to allow partial updates when update/only_new parameters are default.

Add test for partial merge update and check in most new command tests whether the inventory files have all products written to them.