### PR TITLE
Products ranges for generic product metadata

### DIFF
--- a/rechu/alembic/versions/5a5bf02e8988_add_product_metadata_range.py
+++ b/rechu/alembic/versions/5a5bf02e8988_add_product_metadata_range.py
@@ -1,0 +1,53 @@
+"""
+Add product metadata range
+
+Revision ID: 5a5bf02e8988
+Revises: 8ef12eb24650
+Create Date: 2025-06-29 22:58:47.923160
+"""
+# pylint: disable=invalid-name
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.sql import table, column
+
+
+# Revision identifiers, used by Alembic.
+revision: str = '5a5bf02e8988'
+down_revision: Union[str, None] = '8ef12eb24650'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """
+    Perform the upgrade.
+    """
+
+    with op.batch_alter_table('product', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('generic_id', sa.Integer(),
+                                      nullable=True))
+        batch_op.create_foreign_key(batch_op.f('fk_product_generic_id_product'),
+                                    'product', ['generic_id'], ['id'],
+                                    ondelete='CASCADE')
+
+    # ### end Alembic commands ###
+
+
+def downgrade() -> None:
+    """
+    Perform the downgrade.
+    """
+
+    with op.batch_alter_table('product', schema=None) as batch_op:
+        batch_op.drop_constraint(batch_op.f('fk_product_generic_id_product'),
+                                 type_='foreignkey')
+        product = table('product', column('id', sa.Integer()),
+                        column('generic_id', sa.Integer()))
+        batch_op.execute(product.delete()
+                         .where(product.c.generic_id.is_not(None)))
+        batch_op.drop_column('generic_id')
+
+    # ### end Alembic commands ###

--- a/rechu/alembic/versions/d6854aeb9756_add_product_relation_and_shop.py
+++ b/rechu/alembic/versions/d6854aeb9756_add_product_relation_and_shop.py
@@ -36,6 +36,7 @@ def upgrade() -> None:
         start = 0
         for products in Products.read().values():
             end = start + len(products)
+            end += sum(len(product.range) for product in products)
             batch_op.execute(product.update().where(product.c.id.between(start,
                                                                          end))
                              .values(shop=products[0].shop))

--- a/rechu/command/new/__init__.py
+++ b/rechu/command/new/__init__.py
@@ -110,7 +110,7 @@ class New(Base):
             'meta': ['label', 'price', 'discount'] + [
                 column for column, meta in Product.__table__.c.items()
                 if meta.nullable
-            ]
+            ] + ['view']
         })
 
     def run(self) -> None:

--- a/rechu/command/new/step.py
+++ b/rechu/command/new/step.py
@@ -439,10 +439,9 @@ class ProductMeta(Step):
             -> tuple[set[ProductItem], Optional[str]]:
         ok = True
         while ok:
-            ok, initial_key = self._add_key_value(product, item=item,
-                                                  initial_key=initial_key,
-                                                  initial_changed=changed)
-            changed = True
+            ok, initial_key, changed = \
+                self._add_key_value(product, item=item, initial_key=initial_key,
+                                    initial_changed=changed)
 
         items = self._receipt.products if item is None else [item]
         matched = set()
@@ -465,14 +464,18 @@ class ProductMeta(Step):
                        item: Optional[ProductItem] = None,
                        initial_key: Optional[str] = None,
                        initial_changed: Optional[bool] = None) \
-            -> tuple[bool, Optional[str]]:
+            -> tuple[bool, Optional[str], bool]:
         key = self._get_key(item=item, initial_key=initial_key,
                             initial_changed=initial_changed)
 
+        if key == 'view':
+            output = self._input.get_output()
+            ProductsWriter(Path("products.yml"), (product,)).serialize(output)
+            return True, None, bool(initial_changed)
         if key == '':
-            return False, None
+            return False, None, bool(initial_changed)
         if key == '0':
-            return False, key
+            return False, key, bool(initial_changed)
         if key == '?':
             raise ReturnToMenu
 
@@ -480,7 +483,7 @@ class ProductMeta(Step):
             value = self._get_value(item, key)
         except KeyError:
             logging.warning('Unrecognized metadata key %s', key)
-            return True, None
+            return True, None, False
 
         self._set_key_value(product, item, key, value)
 
@@ -499,8 +502,8 @@ class ProductMeta(Step):
         else:
             skip = 'empty or 0 skips meta'
 
-        return self._input.get_input(f'Metadata key ({skip}, ? menu)', str,
-                                     options='meta')
+        return self._input.get_input(f'Metadata key ({skip}, view, ? menu)',
+                                     str, options='meta')
 
     def _get_value(self, item: Optional[ProductItem], key: str) -> Input:
         columns = Product.__table__.c
@@ -566,7 +569,8 @@ class ProductMeta(Step):
 
         return matcher_attrs
 
-    def _check_duplicate(self, product: Product) -> tuple[bool, Optional[str]]:
+    def _check_duplicate(self,
+                         product: Product) -> tuple[bool, Optional[str], bool]:
         existing = self._matcher.check_map(product)
         while existing is not None:
             logging.warning('Product metadata existing: %r', existing)
@@ -578,14 +582,14 @@ class ProductMeta(Step):
                         self._merge(product, existing)
                     except ValueError:
                         logging.exception('Could not merge product metadata')
-                        return True, None
+                        return True, None, True
 
-                    return False, None
+                    return False, None, True
                 logging.warning('Invalid ID: %s', confirm)
             else:
-                return True, confirm
+                return True, confirm, True
 
-        return True, None
+        return True, None, True
 
     def _merge(self, product: Product, existing: Product) -> None:
         product.merge(existing)

--- a/rechu/inventory/products.py
+++ b/rechu/inventory/products.py
@@ -3,7 +3,6 @@ Products inventory.
 """
 
 from collections.abc import Iterable, Iterator, Sequence
-from copy import deepcopy
 import glob
 import logging
 from pathlib import Path
@@ -11,7 +10,7 @@ import re
 from string import Formatter
 from typing import Optional
 from sqlalchemy import select
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, selectinload
 from .base import Inventory, Selectors
 from ..io.products import ProductsReader, ProductsWriter, SharedFields, \
     SHARED_FIELDS
@@ -85,6 +84,7 @@ class Products(dict, Inventory[Product]):
 
         for fields in selectors:
             products = session.scalars(select(Product)
+                                       .options(selectinload(Product.range))
                                        .filter(Product.generic_id.is_(None))
                                        .filter_by(**fields)).all()
             path = data_path / Path(path_format.format(**fields))
@@ -123,7 +123,7 @@ class Products(dict, Inventory[Product]):
         elif only_new:
             return None, False
         elif not update:
-            existing = deepcopy(existing)
+            existing = existing.copy()
         if existing.merge(product):
             changed = True
         return existing, changed

--- a/rechu/inventory/products.py
+++ b/rechu/inventory/products.py
@@ -13,31 +13,29 @@ from typing import Optional
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 from .base import Inventory, Selectors
-from ..io.products import ProductsReader, ProductsWriter
+from ..io.products import ProductsReader, ProductsWriter, SharedFields, \
+    SHARED_FIELDS
 from ..matcher.product import ProductMatcher
 from ..models.product import Product
 from ..settings import Settings
-
-_Parts = tuple[str, ...]
 
 class Products(dict, Inventory[Product]):
     """
     Inventory of products grouped by their identifying fields.
     """
 
-    def __init__(self, mapping = None, /, parts: Optional[_Parts] = None):
+    def __init__(self, mapping = None, /, parts: Optional[SharedFields] = None):
         super().__init__()
         if mapping is not None:
             self.update(mapping)
         if parts is None:
             settings = Settings.get_settings()
-            self._parts = self.get_parts(settings)[2]
-        else:
-            self._parts = parts
+            parts = self.get_parts(settings)[2]
+        self._parts = set(parts)
 
     @staticmethod
     def get_parts(settings: Settings) \
-            -> tuple[str, str, _Parts, re.Pattern[str]]:
+            -> tuple[str, str, SharedFields, re.Pattern[str]]:
         """
         Retrieve various formatting, selecting and matching parts for inventory
         filenames of products.
@@ -45,12 +43,12 @@ class Products(dict, Inventory[Product]):
 
         formatter = Formatter()
         path_format = settings.get('data', 'products')
-        parts = list(formatter.parse(path_format))
-        glob_pattern = '*'.join(glob.escape(part[0]) for part in parts)
-        fields = tuple(part[1] for part in parts if part[1] is not None)
-        path = ''.join(rf"{re.escape(part[0])}(?P<{part[1]}>.*)??"
-                       if part[1] is not None else re.escape(part[0])
-                       for part in parts)
+        prefixes, keys, _, _ = zip(*formatter.parse(path_format))
+        glob_pattern = '*'.join(glob.escape(prefix) for prefix in prefixes)
+        fields = tuple(key for key in keys if key in SHARED_FIELDS)
+        path = ''.join(rf"{re.escape(prefix)}(?P<{key}>.*)??"
+                       if key is not None else re.escape(prefix)
+                       for prefix, key in zip(prefixes, keys))
         pattern = re.compile(rf"(^|.*/){path}$")
         return path_format, glob_pattern, fields, pattern
 
@@ -61,7 +59,7 @@ class Products(dict, Inventory[Product]):
         data_path = settings.get('data', 'path')
         path_format, _, parts, _ = cls.get_parts(settings)
         for model in models:
-            fields = {part: getattr(model, part) for part in parts}
+            fields = {str(part): getattr(model, part) for part in parts}
             path = data_path / Path(path_format.format(**fields))
             inventory.setdefault(path.resolve(), [])
             inventory[path.resolve()].append(model)
@@ -87,6 +85,7 @@ class Products(dict, Inventory[Product]):
 
         for fields in selectors:
             products = session.scalars(select(Product)
+                                       .filter(Product.generic_id.is_(None))
                                        .filter_by(**fields)).all()
             path = data_path / Path(path_format.format(**fields))
             inventory[path.resolve()] = products

--- a/rechu/io/products.py
+++ b/rechu/io/products.py
@@ -5,7 +5,7 @@ Products matching metadata file handling.
 from datetime import datetime
 from pathlib import Path
 from typing import get_args, Collection, Iterable, Iterator, IO, Literal, \
-    Optional, Union
+    Optional, TypeVar, Union
 from typing_extensions import TypedDict
 from .base import YAMLReader, YAMLWriter
 from ..models.base import GTIN, Price, Quantity
@@ -47,6 +47,8 @@ Field = Literal[
     ShareableField, "description", "portions", "weight", "volume", "alcohol",
     "sku", "gtin"
 ]
+_Input = Union[str, int, Quantity]
+_FieldT = TypeVar("_FieldT", bound=_Input)
 SHARED_FIELDS: tuple[ShareableField, ...] = get_args(ShareableField)
 FIELDS: tuple[Field, ...] = get_args(Field)
 
@@ -68,30 +70,45 @@ class ProductsReader(YAMLReader[Product]):
             ]
             yield product
 
+    @staticmethod
+    def _get(input_type: type[_FieldT],
+             value: Optional[_Input]) -> Optional[_FieldT]:
+        if value is not None:
+            value = input_type(value)
+            if not isinstance(value, input_type): # pragma: no cover
+                value = None
+
+        return value
+
     def _product(self, data: _InventoryGroup, generic: _GenericProduct,
                  meta: _Product) -> Product:
         product = Product(shop=data['shop'],
-                          brand=meta.get('brand'),
-                          description=meta.get('description'),
+                          brand=meta.get('brand', generic.get('brand')),
+                          description=meta.get('description',
+                                               generic.get('description')),
                           category=meta.get('category',
                                             generic.get('category',
                                                         data.get('category'))),
                           type=meta.get('type', generic.get('type',
                                                             data.get('type'))),
-                          portions=int(meta['portions']) \
-                                if 'portions' in meta else None,
-                          weight=Quantity(meta['weight']) \
-                                if 'weight' in meta else None,
-                          volume=Quantity(meta['volume']) \
-                                if 'volume' in meta else None,
-                          alcohol=meta.get('alcohol'),
+                          portions=self._get(int,
+                                             meta.get('portions',
+                                                      generic.get('portions'))),
+                          weight=self._get(Quantity,
+                                           meta.get('weight',
+                                                    generic.get('weight'))),
+                          volume=self._get(Quantity,
+                                           meta.get('volume',
+                                                    generic.get('volume'))),
+                          alcohol=meta.get('alcohol', generic.get('volume')),
                           sku=meta.get('sku'),
                           gtin=GTIN(meta['gtin']) if 'gtin' in meta else None)
 
         product.labels = [
-            LabelMatch(name=name) for name in meta.get('labels', [])
+            LabelMatch(name=name)
+            for name in meta.get('labels', generic.get('labels', []))
         ]
-        prices = meta.get('prices', [])
+        prices = meta.get('prices', generic.get('prices', []))
         if isinstance(prices, list):
             product.prices = [
                 PriceMatch(value=Price(price)) for price in prices
@@ -102,7 +119,8 @@ class ProductsReader(YAMLReader[Product]):
                 for key, price in prices.items()
             ]
         product.discounts = [
-            DiscountMatch(label=label) for label in meta.get('bonuses', [])
+            DiscountMatch(label=label)
+            for label in meta.get('bonuses', generic.get('bonuses', []))
         ]
 
         return product
@@ -137,23 +155,29 @@ class ProductsWriter(YAMLWriter[Product]):
         return prices
 
     def _get_product(self, product: Product, skip_fields: set[Field],
-                     skip_data: _GenericProduct) \
+                     generic: _GenericProduct) \
             -> Union[_Product, _GenericProduct]:
         data: Union[_Product, _GenericProduct] = {}
         if 'shop' not in skip_fields:
             data['shop'] = product.shop
-        if product.labels:
-            data['labels'] = [label.name for label in product.labels]
-        if product.prices:
-            data['prices'] = self._get_prices(product)
-        if product.discounts:
-            data['bonuses'] = [discount.label for discount in product.discounts]
+
+        labels = [label.name for label in product.labels]
+        if labels != generic.get('labels', []):
+            data['labels'] = labels
+
+        prices = self._get_prices(product)
+        if prices != generic.get('prices', []):
+            data['prices'] = prices
+
+        discounts = [discount.label for discount in product.discounts]
+        if discounts != generic.get('bonuses', []):
+            data['bonuses'] = discounts
 
         for field in FIELDS:
             column = getattr(Product, field)
             if column.nullable and field not in skip_fields:
                 value = getattr(product, field, None)
-                if value is not None and value != skip_data.get(field):
+                if value is not None and value != generic.get(field):
                     data[field] = value
 
         return data
@@ -164,7 +188,7 @@ class ProductsWriter(YAMLWriter[Product]):
 
         if product.range:
             data['range'] = [
-                self._get_product(sub_product, skip_fields, data)
+                self._get_product(sub_product, skip_fields | {'shop'}, data)
                 for sub_product in product.range
             ]
 

--- a/rechu/io/products.py
+++ b/rechu/io/products.py
@@ -4,13 +4,51 @@ Products matching metadata file handling.
 
 from datetime import datetime
 from pathlib import Path
-from typing import Collection, Iterator, IO, Optional, Union
+from typing import get_args, Collection, Iterable, Iterator, IO, Literal, \
+    Optional, Union
+from typing_extensions import TypedDict
 from .base import YAMLReader, YAMLWriter
 from ..models.base import GTIN, Price, Quantity
 from ..models.product import Product, LabelMatch, PriceMatch, DiscountMatch
 
-_Product = dict[str, Union[str, int, Price, Quantity, list[str], list[Price],
-                           dict[str, Price]]]
+class _Product(TypedDict, total=False):
+    """
+    Serialized product metadata.
+    """
+
+    shop: str
+    labels: list[str]
+    prices: Union[list[Price], dict[str, Price]]
+    bonuses: list[str]
+    brand: str
+    description: str
+    category: str
+    type: str
+    portions: int
+    weight: Quantity
+    volume: Quantity
+    alcohol: str
+    sku: str
+    gtin: int
+
+class _GenericProduct(_Product, total=False):
+    range: list["_Product"]
+
+class _InventoryGroup(TypedDict, total=False):
+    shop: str
+    brand: str
+    category: str
+    type: str
+    products: list[_GenericProduct]
+
+ShareableField = Literal["shop", "brand", "category", "type"]
+SharedFields = Iterable[ShareableField]
+Field = Literal[
+    ShareableField, "description", "portions", "weight", "volume", "alcohol",
+    "sku", "gtin"
+]
+SHARED_FIELDS: tuple[ShareableField, ...] = get_args(ShareableField)
+FIELDS: tuple[Field, ...] = get_args(Field)
 
 class ProductsReader(YAMLReader[Product]):
     """
@@ -18,46 +56,56 @@ class ProductsReader(YAMLReader[Product]):
     """
 
     def parse(self, file: IO) -> Iterator[Product]:
-        data = self.load(file)
+        data: _InventoryGroup = self.load(file)
         if not isinstance(data, dict):
             raise TypeError(f"File '{self._path}' does not contain a mapping")
 
         for meta in data['products']:
-            product = Product(shop=data['shop'],
-                              brand=meta.get('brand'),
-                              description=meta.get('description'),
-                              category=meta.get('category',
-                                                data.get('category')),
-                              type=meta.get('type', data.get('type')),
-                              portions=int(meta['portions']) \
-                                    if 'portions' in meta else None,
-                              weight=Quantity(meta['weight']) \
-                                    if 'weight' in meta else None,
-                              volume=Quantity(meta['volume']) \
-                                    if 'volume' in meta else None,
-                              alcohol=meta.get('alcohol'),
-                              sku=meta.get('sku'),
-                              gtin=GTIN(meta['gtin']) if 'gtin' in meta else \
-                                    None)
-
-            product.labels = [
-                LabelMatch(name=name) for name in meta.get('labels', [])
+            product = self._product(data, {}, meta)
+            product.range = [
+                self._product(data, meta, sub_meta)
+                for sub_meta in meta.get('range', [])
             ]
-            prices = meta.get('prices', [])
-            if isinstance(prices, list):
-                product.prices = [
-                    PriceMatch(value=Price(price)) for price in prices
-                ]
-            else:
-                product.prices = [
-                    PriceMatch(value=Price(price), indicator=key)
-                    for key, price in prices.items()
-                ]
-            product.discounts = [
-                DiscountMatch(label=label) for label in meta.get('bonuses', [])
-            ]
-
             yield product
+
+    def _product(self, data: _InventoryGroup, generic: _GenericProduct,
+                 meta: _Product) -> Product:
+        product = Product(shop=data['shop'],
+                          brand=meta.get('brand'),
+                          description=meta.get('description'),
+                          category=meta.get('category',
+                                            generic.get('category',
+                                                        data.get('category'))),
+                          type=meta.get('type', generic.get('type',
+                                                            data.get('type'))),
+                          portions=int(meta['portions']) \
+                                if 'portions' in meta else None,
+                          weight=Quantity(meta['weight']) \
+                                if 'weight' in meta else None,
+                          volume=Quantity(meta['volume']) \
+                                if 'volume' in meta else None,
+                          alcohol=meta.get('alcohol'),
+                          sku=meta.get('sku'),
+                          gtin=GTIN(meta['gtin']) if 'gtin' in meta else None)
+
+        product.labels = [
+            LabelMatch(name=name) for name in meta.get('labels', [])
+        ]
+        prices = meta.get('prices', [])
+        if isinstance(prices, list):
+            product.prices = [
+                PriceMatch(value=Price(price)) for price in prices
+            ]
+        else:
+            product.prices = [
+                PriceMatch(value=Price(price), indicator=key)
+                for key, price in prices.items()
+            ]
+        product.discounts = [
+            DiscountMatch(label=label) for label in meta.get('bonuses', [])
+        ]
+
+        return product
 
 class ProductsWriter(YAMLWriter[Product]):
     """
@@ -66,9 +114,9 @@ class ProductsWriter(YAMLWriter[Product]):
 
     def __init__(self, path: Path, models: Collection[Product],
                  updated: Optional[datetime] = None,
-                 shared_fields: tuple[str, ...] = ('shop', 'category', 'type')):
+                 shared_fields: SharedFields = ('shop', 'category', 'type')):
         super().__init__(path, models, updated=updated)
-        self._shared_fields = shared_fields
+        self._shared_fields = set(shared_fields)
 
     @staticmethod
     def _get_prices(product: Product) -> Union[list[Price], dict[str, Price]]:
@@ -88,8 +136,10 @@ class ProductsWriter(YAMLWriter[Product]):
 
         return prices
 
-    def _get_product(self, product: Product, skip_fields: set[str]) -> _Product:
-        data: _Product = {}
+    def _get_product(self, product: Product, skip_fields: set[Field],
+                     skip_data: _GenericProduct) \
+            -> Union[_Product, _GenericProduct]:
+        data: Union[_Product, _GenericProduct] = {}
         if 'shop' not in skip_fields:
             data['shop'] = product.shop
         if product.labels:
@@ -99,17 +149,30 @@ class ProductsWriter(YAMLWriter[Product]):
         if product.discounts:
             data['bonuses'] = [discount.label for discount in product.discounts]
 
-        for field, column in Product.__table__.c.items():
+        for field in FIELDS:
+            column = getattr(Product, field)
             if column.nullable and field not in skip_fields:
-                value = getattr(product, field)
-                if value is not None:
+                value = getattr(product, field, None)
+                if value is not None and value != skip_data.get(field):
                     data[field] = value
 
         return data
 
+    def _get_generic_product(self, product: Product, skip_fields: set[Field]) \
+            -> _GenericProduct:
+        data: _GenericProduct = {**self._get_product(product, skip_fields, {})}
+
+        if product.range:
+            data['range'] = [
+                self._get_product(sub_product, skip_fields, data)
+                for sub_product in product.range
+            ]
+
+        return data
+
     def serialize(self, file: IO) -> None:
-        group: dict[str, Union[str, list[_Product]]] = {}
-        skip_fields = set()
+        group: _InventoryGroup = {}
+        skip_fields: set[Field] = set()
         for shared in self._shared_fields:
             values = set(getattr(product, shared) for product in self._models)
             try:
@@ -123,6 +186,7 @@ class ProductsWriter(YAMLWriter[Product]):
                 raise ValueError('Not all products are from the same shop')
 
         group['products'] = [
-            self._get_product(product, skip_fields) for product in self._models
+            self._get_generic_product(product, skip_fields)
+            for product in self._models
         ]
         self.save(group, file)

--- a/rechu/matcher/base.py
+++ b/rechu/matcher/base.py
@@ -49,12 +49,25 @@ class Matcher(Generic[IT, CT]):
         seen: dict[IT, Optional[CT]] = {}
         for candidate, item in candidates:
             if item in seen:
-                seen[item] = None
+                seen[item] = self.select_duplicate(candidate, seen[item])
             else:
                 seen[item] = candidate
         for item, unique in seen.items():
             if unique is not None:
                 yield unique, item
+
+    def select_duplicate(self, candidate: CT, duplicate: Optional[CT]) \
+            -> Optional[CT]: # pylint: disable=unused-argument
+        """
+        Determine which of two candidate models should be matched against some
+        item, if any. If this returns `None` than neither of the models is
+        provided as a match.
+        """
+
+        if candidate is duplicate:
+            return candidate
+
+        return None
 
     def match(self, candidate: CT, item: IT) -> bool:
         """

--- a/rechu/matcher/product.py
+++ b/rechu/matcher/product.py
@@ -3,7 +3,6 @@ Product metadata matcher.
 """
 
 from collections.abc import Collection, Hashable, Iterator
-from itertools import chain
 import logging
 from typing import Optional
 from sqlalchemy import and_, or_, cast, literal, select, Select, String
@@ -31,6 +30,14 @@ class ProductMatcher(Matcher[ProductItem, Product]):
         super().__init__()
         self.discounts = True
 
+    def select_duplicate(self, candidate: Product,
+                         duplicate: Optional[Product]) -> Optional[Product]:
+        if candidate.generic == duplicate:
+            return candidate
+        if duplicate is not None and duplicate.generic == candidate:
+            return duplicate
+        return super().select_duplicate(candidate, duplicate)
+
     def _propose(self, product: Product,
                  item: ProductItem) -> Iterator[tuple[Product, ProductItem]]:
         if self.match(product, item):
@@ -41,14 +48,19 @@ class ProductMatcher(Matcher[ProductItem, Product]):
                                extra: Optional[Collection[Product]],
                                only_unmatched: bool = False) \
             -> Iterator[tuple[Product, ProductItem]]:
-        products = session.scalars(select(Product)
-                                   .filter(Product.generic_id.is_(None))
-                                   .order_by(Product.id)).all()
+        products = \
+            session.scalars(select(Product)
+                            .order_by(Product.generic_id, Product.id)).all()
         for item in items:
             if only_unmatched and item.product_id is not None:
                 continue
-            for product in chain(products, extra if extra is not None else []):
+            for product in products:
                 yield from self._propose(product, item)
+            if extra is not None:
+                for generic in extra:
+                    yield from self._propose(generic, item)
+                    for product_range in generic.range:
+                        yield from self._propose(product_range, item)
 
     def find_candidates(self, session: Session,
                         items: Optional[Collection[ProductItem]] = None,
@@ -71,6 +83,8 @@ class ProductMatcher(Matcher[ProductItem, Product]):
                 seen.add(row.ProductItem)
                 for product in extra:
                     yield from self._propose(product, row.ProductItem)
+                    for product_range in product.range:
+                        yield from self._propose(product_range, row.ProductItem)
 
     def _build_query(self, items: Optional[Collection[ProductItem]],
                      extra: Optional[Collection[Product]],
@@ -131,8 +145,7 @@ class ProductMatcher(Matcher[ProductItem, Product]):
                 .filter(ProductItem.id.in_((item.id for item in items)))
         if only_unmatched:
             query = query.filter(ProductItem.product_id.is_(None))
-        query = query.filter(Product.generic_id.is_(None)) \
-            .order_by(ProductItem.id, Product.id)
+        query = query.order_by(ProductItem.id, Product.generic_id, Product.id)
 
         return query
 
@@ -163,8 +176,7 @@ class ProductMatcher(Matcher[ProductItem, Product]):
     def match(self, candidate: Product, item: ProductItem) -> bool:
         # Candidate must be from the same shop and have at least one matcher
         # Currently, candidate must be generic instead of from a product range
-        if candidate.shop != item.receipt.shop or \
-            candidate.generic is not None or (
+        if candidate.shop != item.receipt.shop or (
                 not candidate.labels and not candidate.prices and
                 not candidate.discounts
             ):

--- a/rechu/matcher/product.py
+++ b/rechu/matcher/product.py
@@ -162,7 +162,9 @@ class ProductMatcher(Matcher[ProductItem, Product]):
 
     def match(self, candidate: Product, item: ProductItem) -> bool:
         # Candidate must be from the same shop and have at least one matcher
-        if candidate.shop != item.receipt.shop or (
+        # Currently, candidate must be generic instead of from a product range
+        if candidate.shop != item.receipt.shop or \
+            candidate.generic is not None or (
                 not candidate.labels and not candidate.prices and
                 not candidate.discounts
             ):

--- a/rechu/matcher/product.py
+++ b/rechu/matcher/product.py
@@ -41,8 +41,9 @@ class ProductMatcher(Matcher[ProductItem, Product]):
                                extra: Optional[Collection[Product]],
                                only_unmatched: bool = False) \
             -> Iterator[tuple[Product, ProductItem]]:
-        products = session.scalars(select(Product).order_by(Product.id)) \
-            .all()
+        products = session.scalars(select(Product)
+                                   .filter(Product.generic_id.is_(None))
+                                   .order_by(Product.id)).all()
         for item in items:
             if only_unmatched and item.product_id is not None:
                 continue
@@ -130,7 +131,8 @@ class ProductMatcher(Matcher[ProductItem, Product]):
                 .filter(ProductItem.id.in_((item.id for item in items)))
         if only_unmatched:
             query = query.filter(ProductItem.product_id.is_(None))
-        query = query.order_by(ProductItem.id, Product.id)
+        query = query.filter(Product.generic_id.is_(None)) \
+            .order_by(ProductItem.id, Product.id)
 
         return query
 

--- a/rechu/models/product.py
+++ b/rechu/models/product.py
@@ -50,6 +50,15 @@ class Product(Base): # pylint: disable=too-few-public-methods
     sku: MappedColumn[Optional[str]]
     gtin: MappedColumn[Optional[GTIN]]
 
+    # Product range differentiation
+    range: Relationship[list["Product"]] = \
+        relationship(back_populates="generic", cascade=_CASCADE_OPTIONS,
+                     passive_deletes=True)
+    generic_id: MappedColumn[Optional[int]] = \
+        mapped_column(ForeignKey(_PRODUCT_REF, ondelete="CASCADE"))
+    generic: Relationship[Optional["Product"]] = \
+        relationship(back_populates="range", remote_side=[id])
+
     def _check_merge(self, other: "Product") -> None:
         if self.prices and other.prices:
             plain = any(price.indicator is None for price in self.prices)
@@ -124,8 +133,8 @@ class LabelMatch(Base): # pylint: disable=too-few-public-methods
     __tablename__ = "product_label_match"
 
     id: MappedColumn[int] = mapped_column(primary_key=True)
-    product_id: MappedColumn[int] = mapped_column(ForeignKey(_PRODUCT_REF,
-                                                       ondelete='CASCADE'))
+    product_id: MappedColumn[int] = \
+        mapped_column(ForeignKey(_PRODUCT_REF, ondelete='CASCADE'))
     product: Relationship[Product] = relationship(back_populates="labels")
     name: MappedColumn[str]
 
@@ -141,8 +150,8 @@ class PriceMatch(Base): # pylint: disable=too-few-public-methods
     __tablename__ = "product_price_match"
 
     id: MappedColumn[int] = mapped_column(primary_key=True)
-    product_id: MappedColumn[int] = mapped_column(ForeignKey(_PRODUCT_REF,
-                                                       ondelete='CASCADE'))
+    product_id: MappedColumn[int] = \
+        mapped_column(ForeignKey(_PRODUCT_REF, ondelete='CASCADE'))
     product: Relationship[Product] = relationship(back_populates="prices")
     value: MappedColumn[Price]
     indicator: MappedColumn[Optional[str]]
@@ -159,8 +168,8 @@ class DiscountMatch(Base): # pylint: disable=too-few-public-methods
     __tablename__ = "product_discount_match"
 
     id: MappedColumn[int] = mapped_column(primary_key=True)
-    product_id: MappedColumn[int] = mapped_column(ForeignKey(_PRODUCT_REF,
-                                                       ondelete='CASCADE'))
+    product_id: MappedColumn[int] = \
+        mapped_column(ForeignKey(_PRODUCT_REF, ondelete='CASCADE'))
     product: Relationship[Product] = relationship(back_populates="discounts")
     label: MappedColumn[str]
 

--- a/rechu/models/product.py
+++ b/rechu/models/product.py
@@ -2,6 +2,7 @@
 Models for product metadata.
 """
 
+from itertools import zip_longest
 from typing import Optional
 from sqlalchemy import ForeignKey, String
 from sqlalchemy.orm import MappedColumn, Relationship, mapped_column, \
@@ -24,13 +25,13 @@ class Product(Base): # pylint: disable=too-few-public-methods
     # Matchers
     labels: Relationship[list["LabelMatch"]] = \
         relationship(back_populates="product", cascade=_CASCADE_OPTIONS,
-                     passive_deletes=True)
+                     passive_deletes=True, lazy="selectin")
     prices: Relationship[list["PriceMatch"]] = \
         relationship(back_populates="product", cascade=_CASCADE_OPTIONS,
-                     passive_deletes=True)
+                     passive_deletes=True, lazy="selectin")
     discounts: Relationship[list["DiscountMatch"]] = \
         relationship(back_populates="product", cascade=_CASCADE_OPTIONS,
-                     passive_deletes=True)
+                     passive_deletes=True, lazy="selectin")
 
     # Descriptors
     brand: MappedColumn[Optional[str]]
@@ -53,11 +54,21 @@ class Product(Base): # pylint: disable=too-few-public-methods
     # Product range differentiation
     range: Relationship[list["Product"]] = \
         relationship(back_populates="generic", cascade=_CASCADE_OPTIONS,
-                     passive_deletes=True)
+                     passive_deletes=True, order_by="Product.id",
+                     lazy="selectin")
     generic_id: MappedColumn[Optional[int]] = \
         mapped_column(ForeignKey(_PRODUCT_REF, ondelete="CASCADE"))
     generic: Relationship[Optional["Product"]] = \
         relationship(back_populates="range", remote_side=[id])
+
+    def copy(self) -> "Product":
+        """
+        Copy the product.
+        """
+
+        copy = Product(shop=self.shop)
+        copy.merge(self)
+        return copy
 
     def _check_merge(self, other: "Product") -> None:
         if self.prices and other.prices:
@@ -103,6 +114,13 @@ class Product(Base): # pylint: disable=too-few-public-methods
                 self.discounts.append(DiscountMatch(label=discount.label))
                 changed = True
 
+        for range_item, range_other in zip_longest(self.range, other.range):
+            if range_item is None:
+                self.range.append(range_other.copy())
+                changed = True
+            elif range_other is not None and range_item.merge(range_other):
+                changed = True
+
         for column, meta in self.__table__.c.items():
             current = getattr(self, column)
             target = getattr(other, column)
@@ -123,7 +141,8 @@ class Product(Base): # pylint: disable=too-few-public-methods
                 f"category={self.category!r}, type={self.type!r}, "
                 f"portions={self.portions!r}, weight={weight!r}, "
                 f"volume={volume!r}, alcohol={self.alcohol!r}, "
-                f"sku={self.sku!r}, gtin={self.gtin!r})")
+                f"sku={self.sku!r}, gtin={self.gtin!r}, "
+                f"range=[{len(self.range)}])")
 
 class LabelMatch(Base): # pylint: disable=too-few-public-methods
     """

--- a/rechu/models/receipt.py
+++ b/rechu/models/receipt.py
@@ -26,8 +26,8 @@ class Receipt(Base): # pylint: disable=too-few-public-methods
         relationship(back_populates="receipt", cascade="all, delete-orphan",
                      passive_deletes=True, order_by="ProductItem.position")
     discounts: Relationship[list["Discount"]] = \
-        relationship(cascade="all, delete-orphan", passive_deletes=True,
-                     order_by="Discount.position")
+        relationship(back_populates="receipt", cascade="all, delete-orphan",
+                     passive_deletes=True, order_by="Discount.position")
 
     @property
     def total_price(self) -> Price:

--- a/samples/new/receipt_invalid_input
+++ b/samples/new/receipt_invalid_input
@@ -78,6 +78,7 @@ brand
 No
 gtin
 4321987654321
+view
 
 
 meta

--- a/samples/products-id.yml
+++ b/samples/products-id.yml
@@ -13,3 +13,10 @@ products:
   bonuses: [disco]
   type: chocolate
   sku: abc123
+  range:
+  - prices: [2.00]
+    description: Small
+    sku: abc123s
+  - prices: [2.50]
+    description: Medium size
+    sku: abc123-m

--- a/schema/products.json
+++ b/schema/products.json
@@ -25,9 +25,14 @@
         },
         "products": {
             "type": "array",
-            "items": {"$ref": "#/$defs/product"}
+            "items": {
+                "allOf": [
+                    {"$ref": "#/$defs/product_meta"},
+                    {"$ref": "#/$defs/product_range"}
+                ]
+            }
         },
-        "product": {
+        "product_meta": {
             "type": "object",
             "properties": {
                 "labels": {
@@ -119,6 +124,15 @@
                     "minimum": 1000000000000,
                     "maximum": 99999999999999,
                     "description": "The Global Trace Item Number of the product, expressed in 14 digits. This is the EAN-13 barcode with a preceding zero."
+                }
+            }
+        },
+        "product_range": {
+            "type": "object",
+            "properties": {
+                "range": {
+                    "type": "array",
+                    "items": {"$ref": "#/$defs/product_meta"}
                 }
             }
         },

--- a/tests/command/alembic.py
+++ b/tests/command/alembic.py
@@ -82,7 +82,8 @@ class AlembicTest(DatabaseTestCase):
         alembic.run()
 
         with self.database as session:
-            self.assertEqual(len(session.scalars(select(Product)).all()),
+            product_query = select(Product).filter(Product.generic_id.is_(None))
+            self.assertEqual(len(session.scalars(product_query).all()),
                              len(products))
             self.assertIsNotNone(session.scalars(select(Receipt)).first())
 

--- a/tests/command/match.py
+++ b/tests/command/match.py
@@ -47,6 +47,8 @@ class MatchTest(DatabaseTestCase):
             if disco is None:
                 self.fail("Expected product to be stored")
             disco.labels = [LabelMatch(name='other')]
+            for product_range in disco.range:
+                product_range.labels = [LabelMatch(name='other')]
             session.merge(disco)
             session.add(Product(shop='id', labels=[LabelMatch(name='bulk')],
                                 type='test'))

--- a/tests/command/new/__init__.py
+++ b/tests/command/new/__init__.py
@@ -4,7 +4,7 @@ Tests of subcommand to create a new receipt YAML file and import it.
 
 from collections.abc import Generator, Iterable
 from contextlib import contextmanager
-from copy import copy, deepcopy
+from copy import deepcopy
 from datetime import datetime, date
 import os
 from pathlib import Path
@@ -20,7 +20,7 @@ from rechu.io.products import ProductsReader
 from rechu.io.receipt import ReceiptReader
 from rechu.models.base import Price, Quantity
 from rechu.models.product import Product, LabelMatch, PriceMatch, DiscountMatch
-from rechu.models.receipt import Receipt
+from rechu.models.receipt import Receipt, ProductItem
 from ...database import DatabaseTestCase
 
 _ExpectedProducts = tuple[Optional[Product], ...]
@@ -110,15 +110,7 @@ class NewTest(DatabaseTestCase):
             for index, (match, item) in enumerate(zip(products_match,
                                                       receipt.products)):
                 with self.subTest(index=index):
-                    if match is None:
-                        self.assertIsNone(item.product)
-                    elif item.product is None:
-                        self.fail(f"Expected {item!r} to match {match!r}")
-                    else:
-                        product_copy = copy(match)
-                        product_copy.id = item.product.id
-                        self.assertFalse(product_copy.merge(item.product),
-                                         f"{match!r} is not match of {item!r}")
+                    self._check_match(match, item)
 
             self.assertTrue(path.exists())
             self.assertEqual(datetime.fromtimestamp(path.stat().st_mtime),
@@ -128,6 +120,22 @@ class NewTest(DatabaseTestCase):
 
             if check_product_inventory:
                 self._check_product_inventory(session, products_match)
+
+    def _check_match(self, match: Optional[Product], item: ProductItem) -> None:
+        if match is None:
+            self.assertIsNone(item.product)
+        elif item.product is None:
+            self.fail(f"Expected {item!r} to match {match!r}")
+        else:
+            product_copy = match.copy()
+            product_copy.id = item.product.id
+            for range_copy, range_item in zip(product_copy.range,
+                                              item.product.range):
+                range_copy.id = range_item.id
+                range_copy.generic_id = range_item.generic_id
+            self.assertFalse(product_copy.merge(item.product),
+                             f"{match!r} should be match of {item.product!r}, "
+                             f"instead the match is {item!r}")
 
     def _match_product(self, match: Product, product: Product) -> bool:
         if match.labels and product.labels:
@@ -170,7 +178,7 @@ class NewTest(DatabaseTestCase):
                     ]
                     self.assertEqual(len(product_matches), 1)
                     match = product_matches[0]
-                    self.assertFalse(copy(match).merge(product),
+                    self.assertFalse(match.copy().merge(product),
                                      f"{product} is not same as {match!r}")
 
     def _check_no_receipt(self, path: Path) -> None:

--- a/tests/command/new/__init__.py
+++ b/tests/command/new/__init__.py
@@ -54,7 +54,7 @@ class NewTest(DatabaseTestCase):
 
         self.products = tuple(ProductsReader(self.inventory).read())
         self.expected_products: _ExpectedProducts = (
-            None, self.products[2], None, self.products[2],
+            None, self.products[2].range[1], None, self.products[2].range[0],
             self.products[0], self.products[1]
         )
         self.replace: tuple[str, str] = ('', '')
@@ -129,13 +129,14 @@ class NewTest(DatabaseTestCase):
         else:
             product_copy = match.copy()
             product_copy.id = item.product.id
+            product_copy.generic_id = item.product.generic_id
             for range_copy, range_item in zip(product_copy.range,
                                               item.product.range):
                 range_copy.id = range_item.id
                 range_copy.generic_id = range_item.generic_id
             self.assertFalse(product_copy.merge(item.product),
-                             f"{match!r} should be match of {item.product!r}, "
-                             f"instead the match is {item!r}")
+                             f"{item!r} should be matched to {match!r}, "
+                             f"instead the match is {item.product!r}")
 
     def _match_product(self, match: Product, product: Product) -> bool:
         if match.labels and product.labels:
@@ -153,7 +154,7 @@ class NewTest(DatabaseTestCase):
                                  .filter(Product.generic_id.is_(None))).all())
         expected_products: set[Product] = {
             product for product in set(self.products) | set(products_match)
-            if product is not None
+            if product is not None and product.generic is None
         }
         self.assertEqual(len(actual_products),
                          len(expected_products),

--- a/tests/command/new/__init__.py
+++ b/tests/command/new/__init__.py
@@ -140,7 +140,9 @@ class NewTest(DatabaseTestCase):
 
     def _check_product_inventory(self, session: Session,
                                  products_match: _ExpectedProducts) -> None:
-        actual_products = list(session.scalars(select(Product)).all())
+        actual_products = \
+            list(session.scalars(select(Product)
+                                 .filter(Product.generic_id.is_(None))).all())
         expected_products: set[Product] = {
             product for product in set(self.products) | set(products_match)
             if product is not None

--- a/tests/command/read.py
+++ b/tests/command/read.py
@@ -24,7 +24,8 @@ class ReadTest(DatabaseTestCase):
     # Number of products in samples/products-id.yml
     product_count = 3
 
-    product_query = select(Product).filter(Product.generic_id.is_(None))
+    # Number of range products in samples/products-id.yml
+    range_count = 2
 
     # Overrides file sorted after samples/products-id.yml
     extra_products = Path("samples/products-id.zzz.yml")
@@ -91,23 +92,24 @@ class ReadTest(DatabaseTestCase):
         command.run()
 
         with self.database as session:
-            products = session.scalars(self.product_query).all()
-            self.assertEqual(len(products), self.product_count)
+            products = session.scalars(select(Product)).all()
+            self.assertEqual(len(products),
+                             self.product_count + self.range_count)
             receipt = self._get_receipt(session)
             updated = receipt.updated
 
             self.assertIsNone(receipt.products[0].product,
                               f"Unexpected match for {receipt.products[0]!r}")
             self.assertEqual(receipt.products[1].product,
-                             products[self.product_count - 1],
+                             products[self.product_count - 1].range[1],
                              f"Expected match for {receipt.products[1]!r}")
 
         # Nothing happens if the directory is not updated.
         command.run()
 
         with self.database as session:
-            self.assertEqual(len(session.scalars(self.product_query).all()),
-                             self.product_count)
+            self.assertEqual(len(session.scalars(select(Product)).all()),
+                             self.product_count + self.range_count)
             receipt = self._get_receipt(session)
             self.assertEqual(receipt.updated, updated)
 
@@ -121,8 +123,8 @@ class ReadTest(DatabaseTestCase):
         command.run()
 
         with self.database as session:
-            self.assertEqual(len(session.scalars(self.product_query).all()),
-                             self.product_count)
+            self.assertEqual(len(session.scalars(select(Product)).all()),
+                             self.product_count + self.range_count)
             receipt = self._get_receipt(session)
             self.assertEqual(receipt.updated, updated)
 
@@ -134,7 +136,8 @@ class ReadTest(DatabaseTestCase):
             command.run()
 
         with self.database as session:
-            products = session.scalars(self.product_query).all()
+            products = session.scalars(select(Product)).all()
+            # The updated products overwrite a product range, so just generics
             self.assertEqual(len(products), self.product_count + 1)
             self.assertEqual(products[self.product_count - 1].prices[0].value,
                              Price('8.00'))
@@ -157,10 +160,11 @@ class ReadTest(DatabaseTestCase):
         command.run()
 
         with self.database as session:
-            products = session.scalars(self.product_query).all()
-            self.assertEqual(len(products), self.product_count)
+            products = session.scalars(select(Product)).all()
+            self.assertEqual(len(products),
+                             self.product_count + self.range_count)
             self.assertIsNone(products[self.product_count - 1].brand)
             receipt = self._get_receipt(session)
             self.assertEqual(receipt.products[1].product,
-                             products[self.product_count - 1],
+                             products[self.product_count - 1].range[1],
                              f"Expected change {receipt.products[1]!r}")

--- a/tests/command/read.py
+++ b/tests/command/read.py
@@ -24,6 +24,8 @@ class ReadTest(DatabaseTestCase):
     # Number of products in samples/products-id.yml
     product_count = 3
 
+    product_query = select(Product).filter(Product.generic_id.is_(None))
+
     # Overrides file sorted after samples/products-id.yml
     extra_products = Path("samples/products-id.zzz.yml")
 
@@ -89,7 +91,7 @@ class ReadTest(DatabaseTestCase):
         command.run()
 
         with self.database as session:
-            products = session.scalars(select(Product)).all()
+            products = session.scalars(self.product_query).all()
             self.assertEqual(len(products), self.product_count)
             receipt = self._get_receipt(session)
             updated = receipt.updated
@@ -104,7 +106,7 @@ class ReadTest(DatabaseTestCase):
         command.run()
 
         with self.database as session:
-            self.assertEqual(len(session.scalars(select(Product)).all()),
+            self.assertEqual(len(session.scalars(self.product_query).all()),
                              self.product_count)
             receipt = self._get_receipt(session)
             self.assertEqual(receipt.updated, updated)
@@ -119,7 +121,7 @@ class ReadTest(DatabaseTestCase):
         command.run()
 
         with self.database as session:
-            self.assertEqual(len(session.scalars(select(Product)).all()),
+            self.assertEqual(len(session.scalars(self.product_query).all()),
                              self.product_count)
             receipt = self._get_receipt(session)
             self.assertEqual(receipt.updated, updated)
@@ -132,7 +134,7 @@ class ReadTest(DatabaseTestCase):
             command.run()
 
         with self.database as session:
-            products = session.scalars(select(Product)).all()
+            products = session.scalars(self.product_query).all()
             self.assertEqual(len(products), self.product_count + 1)
             self.assertEqual(products[self.product_count - 1].prices[0].value,
                              Price('8.00'))
@@ -155,7 +157,7 @@ class ReadTest(DatabaseTestCase):
         command.run()
 
         with self.database as session:
-            products = session.scalars(select(Product)).all()
+            products = session.scalars(self.product_query).all()
             self.assertEqual(len(products), self.product_count)
             self.assertIsNone(products[self.product_count - 1].brand)
             receipt = self._get_receipt(session)

--- a/tests/io/products.py
+++ b/tests/io/products.py
@@ -110,11 +110,9 @@ class ProductsReaderTest(unittest.TestCase):
         for sub, (sub_product, sub_expected) in enumerate(zip(product.range,
                                                               expected_range)):
             with self.subTest(sub_product=sub):
-                combined: _ProductData = {
-                    "category": expected.get("category"),
-                    "type": expected.get("type")
-                }
+                combined = expected.copy()
                 combined.update(sub_expected)
+                combined.pop('range')
                 self._check_product(sub_product, combined)
                 self.assertEqual(sub_product.range, [])
 
@@ -163,13 +161,17 @@ class ProductsWriterTest(unittest.TestCase):
                     type='chocolate',
                     sku='abc123',
                     range=[Product(shop='id',
-                                  prices=[PriceMatch(value=Price('2.00'))],
-                                  description='Small',
-                                  sku='abc123s'),
+                                   prices=[PriceMatch(value=Price('2.00'))],
+                                   discounts=[DiscountMatch(label='disco')],
+                                   description='Small',
+                                   type='chocolate',
+                                   sku='abc123s'),
                             Product(shop='id',
-                                  prices=[PriceMatch(value=Price('2.50'))],
-                                  description='Medium size',
-                                  sku='abc123-m')])
+                                    prices=[PriceMatch(value=Price('2.50'))],
+                                    discounts=[DiscountMatch(label='disco')],
+                                    description='Medium size',
+                                    type='chocolate',
+                                    sku='abc123-m')])
         )
 
     def _check_product(self, actual_product: _ProductData,

--- a/tests/io/products.py
+++ b/tests/io/products.py
@@ -5,8 +5,9 @@ Tests for products matching metadata file handling.
 from io import StringIO
 from itertools import zip_longest
 from pathlib import Path
-from typing import Optional, TypedDict, Union
+from typing import Optional, Union
 import unittest
+from typing_extensions import TypedDict
 import yaml
 from rechu.io.products import ProductsReader, ProductsWriter
 from rechu.models.base import GTIN, Price, Quantity
@@ -19,12 +20,14 @@ class _ProductData(TypedDict, total=False):
     bonuses: list[str]
     category: Optional[str]
     type: Optional[str]
-    portions: Optional[int]
-    weight: Optional[Quantity]
-    sku: Optional[str]
-    gtin: Optional[GTIN]
+    description: str
+    portions: int
+    weight: Quantity
+    sku: str
+    gtin: GTIN
+    range: list["_ProductData"]
 
-expected: list[_ProductData] = [
+EXPECTED: list[_ProductData] = [
     {
         'shop': 'id',
         'labels': ['weigh'],
@@ -45,7 +48,21 @@ expected: list[_ProductData] = [
         'prices': [Price('2.00'), Price('2.50'), Price('3.00')],
         'bonuses': ['disco'],
         'type': 'chocolate',
-        'sku': 'abc123'
+        'sku': 'abc123',
+        'range': [
+            {
+                'shop': 'id',
+                'prices': [Price('2.00')],
+                'description': 'Small',
+                'sku': 'abc123s'
+            },
+            {
+                'shop': 'id',
+                'prices': [Price('2.50')],
+                'description': 'Medium size',
+                'sku': 'abc123-m'
+            }
+        ]
     }
 ]
 
@@ -53,6 +70,53 @@ class ProductsReaderTest(unittest.TestCase):
     """
     Tests for products metadata file reader.
     """
+
+    def _check_product(self, product: Product, expected: _ProductData) -> None:
+        self.assertEqual(product.shop, expected['shop'])
+
+        labels = expected.get('labels', [])
+        self.assertEqual(len(product.labels), len(labels))
+        for label, matcher in zip(product.labels, labels):
+            self.assertEqual(label.name, matcher)
+
+        prices = expected.get('prices', {})
+        self.assertEqual(len(product.prices), len(prices))
+        if isinstance(prices, dict):
+            for price, (key, value) in zip(product.prices, prices.items()):
+                self.assertEqual(price.value, value)
+                self.assertEqual(price.indicator, key)
+        else:
+            for price, value in zip(product.prices, prices):
+                self.assertEqual(price.value, value)
+                self.assertIsNone(price.indicator)
+
+        bonuses = expected.get('bonuses', [])
+        self.assertEqual(len(product.discounts), len(bonuses))
+        for discount, bonus in zip(product.discounts, bonuses):
+            self.assertEqual(discount.label, bonus)
+
+        self.assertEqual(product.category, expected.get('category'))
+        self.assertEqual(product.type, expected.get('type'))
+        self.assertEqual(product.description, expected.get('description'))
+        self.assertEqual(product.portions, expected.get('portions'))
+        self.assertEqual(product.weight, expected.get('weight'))
+        self.assertEqual(product.sku, expected.get('sku'))
+        self.assertEqual(product.gtin, expected.get('gtin'))
+
+    def _check_product_range(self, product: Product,
+                             expected: _ProductData) -> None:
+        expected_range = expected.get('range', [])
+        self.assertEqual(len(product.range), len(expected_range))
+        for sub, (sub_product, sub_expected) in enumerate(zip(product.range,
+                                                              expected_range)):
+            with self.subTest(sub_product=sub):
+                combined: _ProductData = {
+                    "category": expected.get("category"),
+                    "type": expected.get("type")
+                }
+                combined.update(sub_expected)
+                self._check_product(sub_product, combined)
+                self.assertEqual(sub_product.range, [])
 
     def test_parse(self) -> None:
         """
@@ -68,40 +132,9 @@ class ProductsReaderTest(unittest.TestCase):
             index = -1
             for index, product in enumerate(ProductsReader(path).parse(file)):
                 with self.subTest(product=index):
-                    self.assertEqual(product.shop, expected[index]['shop'])
+                    self._check_product(product, EXPECTED[index])
 
-                    labels = expected[index].get('labels', [])
-                    self.assertEqual(len(product.labels), len(labels))
-                    for label, matcher in zip(product.labels, labels):
-                        self.assertEqual(label.name, matcher)
-
-                    prices = expected[index].get('prices', {})
-                    self.assertEqual(len(product.prices), len(prices))
-                    if isinstance(prices, dict):
-                        for price, (key, value) in zip(product.prices,
-                                                       prices.items()):
-                            self.assertEqual(price.value, value)
-                            self.assertEqual(price.indicator, key)
-                    else:
-                        for price, value in zip(product.prices, prices):
-                            self.assertEqual(price.value, value)
-                            self.assertIsNone(price.indicator)
-
-                    bonuses = expected[index].get('bonuses', [])
-                    self.assertEqual(len(product.discounts), len(bonuses))
-                    for discount, bonus in zip(product.discounts, bonuses):
-                        self.assertEqual(discount.label, bonus)
-
-                    self.assertEqual(product.category,
-                                     expected[index].get('category'))
-                    self.assertEqual(product.portions,
-                                     expected[index].get('portions'))
-                    self.assertEqual(product.weight,
-                                     expected[index].get('weight'))
-                    self.assertEqual(product.sku, expected[index].get('sku'))
-                    self.assertEqual(product.gtin, expected[index].get('gtin'))
-
-            self.assertEqual(index, len(expected) - 1)
+            self.assertEqual(index, len(EXPECTED) - 1)
 
 class ProductsWriterTest(unittest.TestCase):
     """
@@ -128,8 +161,62 @@ class ProductsWriterTest(unittest.TestCase):
                     ],
                     discounts=[DiscountMatch(label='disco')],
                     type='chocolate',
-                    sku='abc123')
+                    sku='abc123',
+                    range=[Product(shop='id',
+                                  prices=[PriceMatch(value=Price('2.00'))],
+                                  description='Small',
+                                  sku='abc123s'),
+                            Product(shop='id',
+                                  prices=[PriceMatch(value=Price('2.50'))],
+                                  description='Medium size',
+                                  sku='abc123-m')])
         )
+
+    def _check_product(self, actual_product: _ProductData,
+                       product: _ProductData) -> None:
+        self.assertNotIn('shop', actual_product)
+
+        self.assertEqual(actual_product.get('labels', []),
+                         product.get('labels', []))
+
+        actual_prices = actual_product.get('prices', {})
+        prices = product.get('prices', {})
+        self.assertEqual(len(actual_prices), len(prices))
+        self.assertEqual(type(actual_prices), type(prices))
+        if isinstance(prices, dict):
+            if not isinstance(actual_prices, dict): # pragma: no cover
+                self.fail("Type unexpectedly not a dict")
+            for (end, price), (key, value) in zip(actual_prices.items(),
+                                                  prices.items()):
+                self.assertEqual(end, key)
+                self.assertEqual(price, float(value))
+        else:
+            if not isinstance(actual_prices, list): # pragma: no cover
+                self.fail("Type unexpectedly not a list")
+            for price, value in zip(actual_prices, prices):
+                self.assertEqual(price, float(value))
+
+        self.assertEqual(actual_product.get('bonuses', []),
+                         product.get('bonuses', []))
+
+        self.assertEqual(actual_product.get('category'),
+                         product.get('category'))
+        self.assertEqual(actual_product.get('type'), product.get('type'))
+        self.assertEqual(actual_product.get('description'),
+                         product.get('description'))
+        self.assertEqual(actual_product.get('portions'),
+                         product.get('portions'))
+        if 'weight' not in actual_product:
+            self.assertNotIn('weight', product)
+        else:
+            self.assertEqual(Quantity(actual_product['weight']),
+                             product.get('weight'))
+        self.assertEqual(actual_product.get('sku'), product.get('sku'))
+        if 'gtin' not in actual_product:
+            self.assertNotIn('gtin', product)
+        else:
+            self.assertEqual(GTIN(actual_product['gtin']),
+                             product.get('gtin'))
 
     def test_serialize(self) -> None:
         """
@@ -144,49 +231,20 @@ class ProductsWriterTest(unittest.TestCase):
         actual = yaml.safe_load('\n'.join(file.readlines()))
 
         self.assertEqual(actual['shop'], 'id')
-        self.assertEqual(len(actual['products']), len(expected))
-        for index, product in enumerate(expected):
+        self.assertEqual(len(actual['products']), len(EXPECTED))
+        for index, product in enumerate(EXPECTED):
             with self.subTest(product=index):
                 actual_product = actual['products'][index]
-                self.assertNotIn('shop', actual_product)
-
-                self.assertEqual(actual_product.get('labels', []),
-                                 product.get('labels', []))
-
-                actual_prices = actual_product.get('prices', {})
-                prices = product.get('prices', {})
-                self.assertEqual(len(actual_prices), len(prices))
-                self.assertEqual(type(actual_prices), type(prices))
-                if isinstance(prices, dict):
-                    for (end, price), (key, value) in zip(actual_prices.items(),
-                                                          prices.items()):
-                        self.assertEqual(end, key)
-                        self.assertEqual(price, float(value))
+                self._check_product(actual_product, product)
+                if 'range' not in actual_product:
+                    self.assertNotIn('range', product)
                 else:
-                    for price, value in zip(actual_prices, prices):
-                        self.assertEqual(price, float(value))
-
-                self.assertEqual(actual_product.get('bonuses', []),
-                                 product.get('bonuses', []))
-
-                self.assertEqual(actual_product.get('category'),
-                                 product.get('category'))
-                self.assertEqual(actual_product.get('type'),
-                                 product.get('type'))
-                self.assertEqual(actual_product.get('portions'),
-                                 product.get('portions'))
-                if 'weight' not in actual_product:
-                    self.assertNotIn('weight', product)
-                else:
-                    self.assertEqual(Quantity(actual_product.get('weight')),
-                                     product.get('weight'))
-                self.assertEqual(actual_product.get('sku'),
-                                 product.get('sku'))
-                if 'gtin' not in actual_product:
-                    self.assertNotIn('gtin', product)
-                else:
-                    self.assertEqual(GTIN(actual_product['gtin']),
-                                     product.get('gtin'))
+                    self.assertEqual(len(actual_product['range']),
+                                     len(product['range']))
+                    for sub_actual, sub_product in zip(actual_product['range'],
+                                                       product['range']):
+                        self._check_product(sub_actual, sub_product)
+                        self.assertNotIn('range', sub_actual)
 
     def test_serialize_roundtrip(self) -> None:
         """

--- a/tests/matcher/base.py
+++ b/tests/matcher/base.py
@@ -38,6 +38,17 @@ class MatcherTest(unittest.TestCase):
                                                         (four, two)])
         self.assertEqual(list(filtered), [(four, two)])
 
+    def test_select_duplicate(self) -> None:
+        """
+        Test deremining which candiate model should be matched against an item.
+        """
+
+        matcher: Matcher[TestEntity, TestEntity] = Matcher()
+        one = TestEntity(id=1)
+        two = TestEntity(id=2)
+        self.assertIsNone(matcher.select_duplicate(one, two))
+        self.assertIs(matcher.select_duplicate(one, one), one)
+
     def test_match(self) -> None:
         """
         Test checking if a candidate model matches an item model.

--- a/tests/matcher/product.py
+++ b/tests/matcher/product.py
@@ -61,10 +61,12 @@ class ProductMatcherTest(DatabaseTestCase):
         self.assertEqual(list(matcher.find_candidates(session, search_items,
                                                       extra_products)),
                          [
-                             # [2, bulk, 5.00, bonus]; [disco, -2.00, bulk
+                             # [2, bulk, 5.00, bonus]; [disco, -2.00, bulk; sub
                              (products[2], items[1]),
-                             # [4, bulk, 8.00, bonus]; [disco, -2.00, bulk
+                             (products[2].range[1], items[1]),
+                             # [4, bulk, 8.00, bonus]; [disco, -2.00, bulk; sub
                              (products[2], items[3]),
+                             (products[2].range[0], items[3]),
                              # [0.750kg, weigh, 2.50]
                              (products[0], items[4]),
                              # [1, due, 0.89, 25%]
@@ -72,7 +74,12 @@ class ProductMatcherTest(DatabaseTestCase):
                          ])
         self.assertEqual(list(matcher.find_candidates(session, items[:4],
                                                       extra_products)),
-                         [(products[2], items[1]), (products[2], items[3])])
+                         [
+                             (products[2], items[1]),
+                             (products[2].range[1], items[1]),
+                             (products[2], items[3]),
+                             (products[2].range[0], items[3])
+                         ])
 
         return products, items
 
@@ -89,15 +96,23 @@ class ProductMatcherTest(DatabaseTestCase):
             matcher = ProductMatcher()
             self.assertEqual(list(matcher.find_candidates(session, items[:4],
                                                           only_unmatched=True)),
-                             [(products[2], items[1])])
+                             [
+                                 (products[2], items[1]),
+                                 (products[2].range[1], items[1])
+                             ])
 
             items[3].discounts = []
             session.flush()
             matcher.discounts = False
             self.assertEqual(list(matcher.find_candidates(session, items[:4])),
-                             [(products[2], items[1]),
-                              (products[2], items[2]),
-                              (products[2], items[3])])
+                             [
+                                 (products[2], items[1]),
+                                 (products[2].range[1], items[1]),
+                                 (products[2], items[2]),
+                                 (products[2].range[1], items[2]),
+                                 (products[2], items[3]),
+                                 (products[2].range[0], items[3])
+                             ])
 
             matcher.discounts = True
 
@@ -121,6 +136,10 @@ class ProductMatcherTest(DatabaseTestCase):
                     MagicMock(Product=products[0], ProductItem=items[1]),
                     MagicMock(Product=products[1], ProductItem=items[1]),
                     MagicMock(Product=products[2], ProductItem=items[1]),
+                    MagicMock(Product=products[2].range[0],
+                              ProductItem=items[1]),
+                    MagicMock(Product=products[2].range[1],
+                              ProductItem=items[1]),
                     MagicMock(Product=fake_shop, ProductItem=items[1]),
                     MagicMock(Product=fake_price, ProductItem=items[1]),
                     MagicMock(Product=fake_range, ProductItem=items[1]),
@@ -131,7 +150,10 @@ class ProductMatcherTest(DatabaseTestCase):
             fake_session.configure_mock(**session_attrs)
             # Post-processing filter removes invalid matches.
             self.assertEqual(list(matcher.find_candidates(fake_session)),
-                             [(products[2], items[1])])
+                             [
+                                 (products[2], items[1]),
+                                 (products[2].range[1], items[1])
+                             ])
 
     def test_find_candidates_dirty(self) -> None:
         """
@@ -145,7 +167,10 @@ class ProductMatcherTest(DatabaseTestCase):
             matcher = ProductMatcher()
             self.assertEqual(list(matcher.find_candidates(session, items[:4],
                                                           only_unmatched=True)),
-                             [(products[2], items[1])])
+                             [
+                                 (products[2], items[1]),
+                                 (products[2].range[1], items[1])
+                             ])
 
     def test_find_candidates_extra(self) -> None:
         """
@@ -165,6 +190,21 @@ class ProductMatcherTest(DatabaseTestCase):
         with self.database as session:
             self._test_samples(session, insert_products=False,
                                insert_receipt=False)
+
+    def test_select_duplicate(self) -> None:
+        """
+        Test determining which candidate product should be matched against
+        a product item.
+        """
+
+        matcher = ProductMatcher()
+        product = Product(shop='id', range=[Product(shop='id')])
+        self.assertIs(matcher.select_duplicate(product.range[0], product),
+                      product.range[0])
+        self.assertIs(matcher.select_duplicate(product, product.range[0]),
+                      product.range[0])
+        self.assertIsNone(matcher.select_duplicate(product, Product(shop='id')))
+        self.assertIs(matcher.select_duplicate(product, product), product)
 
     def test_match(self) -> None:
         """

--- a/tests/models/product.py
+++ b/tests/models/product.py
@@ -13,6 +13,24 @@ class ProductTest(DatabaseTestCase):
     Tests for product model.
     """
 
+    def test_copy(self) -> None:
+        """
+        Test copying the product.
+        """
+
+        product = Product(shop='id', labels=[LabelMatch(name='first')],
+                          prices=[], discounts=[DiscountMatch(label='one')],
+                          brand='abc', description='def',
+                          category='foo', type='bar', portions=12,
+                          range=[Product(shop='id')])
+        copy = product.copy()
+        self.assertIsNot(product, copy)
+        self.assertEqual(product.shop, copy.shop)
+        self.assertEqual([label.name for label in product.labels],
+                         [label.name for label in copy.labels])
+        self.assertEqual(len(product.range), len(copy.range))
+        self.assertFalse(product.merge(copy))
+
     def test_merge(self) -> None:
         """
         Test merging attributes of another product.
@@ -24,7 +42,8 @@ class ProductTest(DatabaseTestCase):
         product = Product(shop='id', labels=[LabelMatch(name='first')],
                           prices=prices, discounts=[DiscountMatch(label='one')],
                           brand='abc', description='def',
-                          category='foo', type='bar', portions=12)
+                          category='foo', type='bar', portions=12,
+                          range=[Product(shop='id')])
         other = Product(id=3, shop='ignore',
                         labels=[
                             LabelMatch(name='first'), LabelMatch(name='second')
@@ -33,7 +52,8 @@ class ProductTest(DatabaseTestCase):
                             DiscountMatch(label='one'), DiscountMatch(label='2')
                         ],
                         weight=Quantity('750g'), volume=Quantity('1l'),
-                        alcohol='2.0%', sku='1234', gtin=1234567890123)
+                        alcohol='2.0%', sku='1234', gtin=1234567890123,
+                        range=[Product(sku='5x'), Product(shop='id', sku='5y')])
 
         self.assertTrue(product.merge(other))
 
@@ -62,6 +82,12 @@ class ProductTest(DatabaseTestCase):
         self.assertEqual(product.alcohol, '2.0%')
         self.assertEqual(product.sku, '1234')
         self.assertEqual(product.gtin, 1234567890123)
+
+        self.assertEqual(len(product.range), 2)
+        self.assertEqual(product.range[0].shop, 'id')
+        self.assertEqual(product.range[0].sku, '5x')
+        self.assertEqual(product.range[1].shop, 'id')
+        self.assertEqual(product.range[1].sku, '5y')
 
         self.assertFalse(product.merge(other))
 
@@ -121,7 +147,7 @@ class ProductTest(DatabaseTestCase):
                          "discounts=[], brand='abc', description='def', "
                          "category='foo', type='bar', portions=12, "
                          "weight='750g', volume='1l', alcohol='2.0%', "
-                         "sku='1234', gtin=1234567890123)")
+                         "sku='1234', gtin=1234567890123, range=[0])")
         product.labels = [LabelMatch(product=product, name='label')]
         product.prices = [
             PriceMatch(product=product, value=Price('1.23'),
@@ -132,6 +158,7 @@ class ProductTest(DatabaseTestCase):
         product.discounts = [DiscountMatch(product=product, label='disco')]
         product.type = None
         product.volume = None
+        product.range = [Product(shop='id', sku='5')]
         with self.database as session:
             session.add(product)
             session.flush()
@@ -141,4 +168,5 @@ class ProductTest(DatabaseTestCase):
                              "discounts=['disco'], brand='abc', "
                              "description='def', category='foo', type=None, "
                              "portions=12, weight='750g', volume=None, "
-                             "alcohol='2.0%', sku='1234', gtin=1234567890123)")
+                             "alcohol='2.0%', sku='1234', gtin=1234567890123, "
+                             "range=[1])")


### PR DESCRIPTION
- [x] Specify product ranges as sub-products of a generic product with overrides for assortment differentiation like size
- [x] Read and write product ranges with inheritance and skipping of generic fields, respectively
- [x] Prefer matching product ranges with receipt product items over their generic product metadata
- [ ] Prefer matching the generic product if all of the product range have the same match specificity
- [x] New: Display current product meta state with 'view' key during metadata creation
- [ ] New: Create product ranges with inheritance of generic fields
- [ ] Documentation and changelog