### PR TITLE
New: Product metadata edit

### DIFF
--- a/rechu/io/products.py
+++ b/rechu/io/products.py
@@ -84,7 +84,7 @@ class ProductsReader(YAMLReader[Product]):
 
     def _product(self, data: _InventoryGroup, generic: _GenericProduct,
                  meta: _Product) -> Product:
-        product = Product(shop=data['shop'],
+        product = Product(shop=data.get('shop', generic.get('shop')),
                           brand=meta.get('brand', generic.get('brand')),
                           description=meta.get('description',
                                                generic.get('description')),

--- a/samples/new/receipt_invalid_input
+++ b/samples/new/receipt_invalid_input
@@ -58,6 +58,7 @@ type
 sweet
 type
 
+edit
 category
 candy
 
@@ -136,6 +137,15 @@ sp900
 -1
 m
 0
+m
+sku
+sp9990
+price
+1.00
+
+edit
+edit
+?
 m
 
 

--- a/tests/models/product.py
+++ b/tests/models/product.py
@@ -41,6 +41,74 @@ class ProductTest(DatabaseTestCase):
                                  Product(sku='5x'), Product(shop='id', sku='5y')
                              ])
 
+    def test_clear(self) -> None:
+        """
+        Test removing all properties of the product.
+        """
+
+        self.product.clear()
+        self.assertEqual(self.product.shop, 'id')
+        self.assertEqual(self.product.labels, [])
+        self.assertEqual(self.product.prices, [])
+        self.assertEqual(self.product.discounts, [])
+        self.assertEqual(self.product.range, [])
+        self.assertIsNone(self.product.brand)
+
+        self.other.range[1].clear()
+        self.assertEqual(self.other.range[1].shop, 'id')
+        self.assertEqual(len(self.other.range[1].labels), 2)
+        self.assertEqual(self.other.range[1].labels[0].name, 'first')
+        self.assertEqual(self.other.range[1].labels[1].name, 'second')
+        self.assertEqual(self.other.range[1].prices, [])
+        self.assertEqual(len(self.other.range[1].discounts), 2)
+        self.assertEqual(self.other.range[1].discounts[0].label, 'one')
+        self.assertEqual(self.other.range[1].discounts[1].label, '2')
+        self.assertEqual(self.other.range[1].alcohol, '2.0%')
+        self.assertEqual(self.other.range[1].generic, self.other)
+
+    def test_replace(self) -> None:
+        """
+        Test replacing all properties with those defined in the new product.
+        """
+
+        self.product.replace(Product(gtin=4321987654321))
+        self.assertEqual(self.product.shop, 'id')
+        self.assertEqual(self.product.labels, [])
+        self.assertEqual(self.product.prices, [])
+        self.assertEqual(self.product.discounts, [])
+        self.assertEqual(self.product.range, [])
+        self.assertIsNone(self.product.brand)
+        self.assertEqual(self.product.gtin, 4321987654321)
+
+        self.other.range[1].replace(Product(sku='5z'))
+        self.assertEqual(self.other.range[1].shop, 'id')
+        self.assertEqual(len(self.other.range[1].labels), 2)
+        self.assertEqual(self.other.range[1].labels[0].name, 'first')
+        self.assertEqual(self.other.range[1].labels[1].name, 'second')
+        self.assertEqual(self.other.range[1].prices, [])
+        self.assertEqual(len(self.other.range[1].discounts), 2)
+        self.assertEqual(self.other.range[1].discounts[0].label, 'one')
+        self.assertEqual(self.other.range[1].discounts[1].label, '2')
+        self.assertEqual(self.other.range[1].alcohol, '2.0%')
+        self.assertEqual(self.other.range[1].sku, '5z')
+        self.assertEqual(self.other.range[1].generic, self.other)
+
+        # Replacing matchers override generic matchers.
+        self.other.range[1].replace(Product(labels=[LabelMatch(name='init')],
+                                            prices=[
+                                                PriceMatch(value=Price('1.00'))
+                                            ],
+                                            discounts=[
+                                                DiscountMatch(label='tri')
+                                            ]))
+        self.assertEqual(len(self.other.range[1].labels), 1)
+        self.assertEqual(self.other.range[1].labels[0].name, 'init')
+        self.assertEqual(len(self.other.range[1].prices), 1)
+        self.assertEqual(self.other.range[1].prices[0].value, Price('1.00'))
+        self.assertEqual(len(self.other.range[1].discounts), 1)
+        self.assertEqual(self.other.range[1].discounts[0].label, 'tri')
+
+
     def test_copy(self) -> None:
         """
         Test copying the product.


### PR DESCRIPTION
- Merge fields by clearing and replacing, taking generic into account. In fact, edit in a product range is basically the same as editing generic product except you cannot remove the product range.
- Meta edit properly uses non-shared shop field from the product.
- Handle conversion errors from edit step and meta edit
- Avoid merging product range if the target product is not generic
- Mention edit in meta prompt, only mention view after a change