### PR TITLE
New: Fix merging metadata with existing DB product

### DIFF
--- a/rechu/inventory/products.py
+++ b/rechu/inventory/products.py
@@ -86,7 +86,8 @@ class Products(dict, Inventory[Product]):
 
         for fields in selectors:
             products = session.scalars(select(Product)
-                                       .options(selectinload(Product.range))
+                                       .options(selectinload(Product.range),
+                                                selectinload(Product.generic))
                                        .filter(Product.generic_id.is_(None))
                                        .filter_by(**fields)).all()
             path = data_path / Path(path_format.format(**fields))

--- a/rechu/matcher/product.py
+++ b/rechu/matcher/product.py
@@ -62,6 +62,8 @@ class ProductMatcher(Matcher[ProductItem, Product]):
     def select_duplicate(self, candidate: Product,
                          duplicate: Optional[Product]) -> Optional[Product]:
         if duplicate is not None:
+            if candidate.id is not None and candidate.id == duplicate.id:
+                return candidate
             if candidate.generic == duplicate:
                 return self._select_generic(duplicate, candidate)
             if duplicate.generic == candidate:

--- a/rechu/models/product.py
+++ b/rechu/models/product.py
@@ -62,7 +62,7 @@ class Product(Base): # pylint: disable=too-few-public-methods
     generic_id: MappedColumn[Optional[int]] = \
         mapped_column(ForeignKey(_PRODUCT_REF, ondelete="CASCADE"))
     generic: Relationship[Optional["Product"]] = \
-        relationship(back_populates="range", remote_side=[id])
+        relationship(back_populates="range", remote_side=[id], lazy="selectin")
 
     def clear(self) -> None:
         """

--- a/samples/new/product_db_merge_input
+++ b/samples/new/product_db_merge_input
@@ -1,0 +1,11 @@
+# /#Chained from receipt_input with confirm mode on/x
+n                   # /Confirm .* write the completed receipt and exit/
+m                   # Menu
+brand				# Metadata key
+CrispCrops			# Brand
+label               # Metadata key
+weigh               # Label
+1                   # Confirm merge by ID (1 or negative to add to range)
+                    # empty or 0 skips meta
+w                   # Menu
+y                   # /Confirm .* write completed receipt and product metadata/

--- a/tests/matcher/product.py
+++ b/tests/matcher/product.py
@@ -198,6 +198,12 @@ class ProductMatcherTest(DatabaseTestCase):
         """
 
         matcher = ProductMatcher()
+
+        dupe = Product(id=99, shop='id')
+        self.assertIs(matcher.select_duplicate(dupe, Product(id=99, shop='id')),
+                      dupe)
+        self.assertIsNone(matcher.select_duplicate(dupe, Product(shop='id')))
+
         simple = Product(shop='id', range=[Product(shop='id')])
         self.assertIs(matcher.select_duplicate(simple.range[0], simple), simple)
         self.assertIs(matcher.select_duplicate(simple, simple.range[0]), simple)


### PR DESCRIPTION
- Make products not expire upon session commit when filling matcher
- Merge the receipt and associated entities instead of adding to make merged products merge
- Consider product items that were matched with a product already to indicate the new/merged product has a match on the receipt
- Consider matches of products even if they are provided multiple times (possibly as different objects from DB/input) as long as they have the same ID
- Eager load range product's generic ID