### PR TITLE
New: Check discount match counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and we adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Cancel adding product item in `new` subcommand during label, price or 
   discount indicator input, similar to discount items and product metadata.
+- Limit addition of discounts and product metadata in `new` subcommand unless 
+  `--more` argument is used, while accepting more specific metadata when there 
+  are multiple or partial matches.
 
 ## [0.0.1] - 2025-08-02
 

--- a/docs/source/commands.md
+++ b/docs/source/commands.md
@@ -80,7 +80,13 @@ earlier products may be created with the `meta` step. This includes writing
 assortments of product ranges which have a shared generic product whose 
 properties are inherited. If a product is created with similar matchers or 
 identifiers as an existing metadata item, then an opportunity is given to merge 
-them together or to add more matcher fields to distinguish the former.
+them together or to add more matcher fields to distinguish the former. 
+
+Normally, once all discounted products are matched with discounts or all 
+product items are matched with metadata, no more can be created in their 
+respective steps, but if you run the command as `rechu new -m`, this 
+restriction is waived, which may be helpful for certain receipts with multiple 
+discounts or for making more specific metadata.
 
 To finish the file generation and import after using the menu, use the `write` 
 step. If you run the command as `rechu new -c`, then this step will ask for 

--- a/rechu/command/new/__init__.py
+++ b/rechu/command/new/__init__.py
@@ -11,8 +11,8 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 from sqlalchemy.sql.functions import min as min_, max as max_
 from .input import InputSource, Prompt
-from .step import Menu, ProductsMeta, ResultMeta, ReturnToMenu, Step, \
-    Read, Products, Discounts, ProductMeta, View, Write, Edit, Quit, Help
+from .step import Menu, ReturnToMenu, Step, Read, Products, Discounts, \
+    ProductMeta, View, Write, Edit, Quit, Help
 from ..base import Base
 from ...database import Database
 from ...io.products import OPTIONAL_FIELDS
@@ -132,19 +132,17 @@ class New(Base):
         path = self._get_path(receipt_date, shop)
         receipt = Receipt(filename=path.name, updated=datetime.now(),
                           date=receipt_date.date(), shop=shop)
-        products: ProductsMeta = set()
-        write = Write(receipt, input_source, matcher=matcher, products=products)
+        write = Write(receipt, input_source, matcher=matcher)
         write.path = path
         usage = Help(receipt, input_source)
         menu: Menu = {
             'read': Read(receipt, input_source, matcher=matcher),
-            'products': Products(receipt, input_source, matcher=matcher,
-                                 products=products),
+            'products': Products(receipt, input_source, matcher=matcher),
             'discounts': Discounts(receipt, input_source, matcher=matcher,
                                    more=self.more),
             'meta': ProductMeta(receipt, input_source, matcher=matcher,
-                                products=products),
-            'view': View(receipt, input_source, products=products),
+                                more=self.more),
+            'view': View(receipt, input_source),
             'write': write,
             'edit': Edit(receipt, input_source,
                          editor=self.settings.get('data', 'editor')),

--- a/rechu/command/new/__init__.py
+++ b/rechu/command/new/__init__.py
@@ -37,12 +37,18 @@ class New(Base):
             'action': 'store_true',
             'default': False,
             'help': 'Confirm before updating database files or exiting'
+        }),
+        (('-m', '--more'), {
+            'action': 'store_true',
+            'default': False,
+            'help': 'Allow more discounts and metadata than there are products'
         })
     ]
 
     def __init__(self) -> None:
         super().__init__()
         self.confirm = False
+        self.more = False
 
     def _get_menu_step(self, menu: Menu, input_source: InputSource) -> Step:
         choice: Optional[str] = None
@@ -134,7 +140,8 @@ class New(Base):
             'read': Read(receipt, input_source, matcher=matcher),
             'products': Products(receipt, input_source, matcher=matcher,
                                  products=products),
-            'discounts': Discounts(receipt, input_source, matcher=matcher),
+            'discounts': Discounts(receipt, input_source, matcher=matcher,
+                                   more=self.more),
             'meta': ProductMeta(receipt, input_source, matcher=matcher,
                                 products=products),
             'view': View(receipt, input_source, products=products),

--- a/rechu/command/new/step.py
+++ b/rechu/command/new/step.py
@@ -244,24 +244,24 @@ class Products(Step):
 
     def _make_meta(self, item: ProductItem, prompt: str,
                    pairs: _Pairs, dedupe: _Pairs) -> Union[str, Quantity]:
+        match = dedupe and not dedupe[0][0].discounts and len(pairs) == 1
+        match_prompt = 'More specific metadata accepted' if dedupe else \
+            'No metadata yet'
         if dedupe and dedupe[0][0].discounts:
             LOGGER.info('Matched with %r excluding discounts', dedupe[0][0])
         elif dedupe:
             LOGGER.info('Matched with %r', dedupe[0][0])
-        elif len(pairs) > 1:
-            LOGGER.warning('Multiple metadata matches, ignoring for now')
-        else:
-            match = False
-            while not match:
-                meta_prompt = f'No metadata yet. Next {prompt.lower()} or key'
-                key = self._input.get_input(meta_prompt, str, options='meta')
-                if key in {'', '?', '!'} or key[0].isnumeric():
-                    # Quantity or other product item command
-                    return key
 
-                product = ProductMeta(self._receipt, self._input,
-                                      matcher=self._matcher)
-                match = not product.add_product(item=item, initial_key=key)[0]
+        while not match:
+            meta_prompt = f'{match_prompt}. Next {prompt.lower()} or key'
+            key = self._input.get_input(meta_prompt, str, options='meta')
+            if key in {'', '?', '!'} or key[0].isnumeric():
+                # Quantity or other product item command
+                return key
+
+            product = ProductMeta(self._receipt, self._input,
+                                  matcher=self._matcher)
+            match = not product.add_product(item=item, initial_key=key)[0]
 
         return self._input.get_input(prompt, str)
 

--- a/rechu/matcher/product.py
+++ b/rechu/matcher/product.py
@@ -44,8 +44,8 @@ class ProductMatcher(Matcher[ProductItem, Product]):
     def _get_specificity(self, product: Product) -> tuple[int, ...]:
         # A product has higher specificity if it has more of the three types
         # of matcher fields (label/price/discount) than another product, or if
-        # theyboth have the same of these, then it is preferred if it has fewer
-        # of those fields.
+        # they both have the same of these, then it is preferred if it has
+        # fewer of the individual fields.
         matchers = bool(product.labels) + bool(product.prices)
         matcher_fields = len(product.labels) + len(product.prices)
         if self.discounts:

--- a/samples/new/invalid_input
+++ b/samples/new/invalid_input
@@ -10,5 +10,5 @@ h                   # Menu
 products            # Menu
 ?                   # ? to menu
 discounts           # Menu
-?                   # /# there is no message in discounts to return to menu/x
+?                   # ? to menu
 w                   # Menu

--- a/samples/new/product_db_merge_input
+++ b/samples/new/product_db_merge_input
@@ -1,5 +1,5 @@
 # /#Chained from receipt_input with confirm mode on/x
-n                   # /Confirm .* write the completed receipt and exit/
+n                   # /Confirm .* write the completed receipt/
 m                   # Menu
 brand				# Metadata key
 CrispCrops			# Brand
@@ -8,4 +8,4 @@ weigh               # Label
 1                   # Confirm merge by ID (1 or negative to add to range)
                     # empty or 0 skips meta
 w                   # Menu
-y                   # /Confirm .* write completed receipt and product metadata/
+y                   # /Confirm .* write the completed receipt/

--- a/samples/new/receipt_invalid_input
+++ b/samples/new/receipt_invalid_input
@@ -19,7 +19,7 @@ none                # Label
 bar                 # Label
 baz                 # Price
 0.01                # Price
-                    # Discount indicator
+~                   # Discount indicator
 price               # /Metadata .*key/i
 0.02                # Price (empty for "0.01")
                     # Indicator
@@ -102,8 +102,12 @@ fine                # Discount label
 1.45                # Price decrease (positive cancels)
 clash               # Discount label
 -0.50               # Price decrease
-xyz                 # Product
+bar                 # Product
 !                   # ! cancels
+!                   # ! cancels
+tare                # Discount label
+-1.23               # Price decrease
+xyz                 # Product
 !                   # ! cancels
 rate                # Discount label
 -0.50               # Price decrease

--- a/samples/new/receipt_invalid_input
+++ b/samples/new/receipt_invalid_input
@@ -188,9 +188,8 @@ m                   # Menu
 label               # Metadata key
 qux                 # Label
                     # empty ends this meta
-m                   # Menu
 view                # Menu
 w                   # Menu
-n                   # /Confirm .* write completed receipt and product metadata/
+n                   # /Confirm .* write the completed receipt/
 w                   # Menu
-y                   # /Confirm .* write completed receipt and product metadata/
+y                   # /Confirm .* write the completed receipt/

--- a/samples/new/receipt_valid_input
+++ b/samples/new/receipt_valid_input
@@ -1,0 +1,36 @@
+2024-11-01 12:34 # Date/time
+id               # Shop
+1                # /Quantity/i
+label            # Label
+0.99             # Price
+                 # Discount indicator
+2                # /Quantity/i
+bulk             # Label
+5.00             # Price
+bonus            # Discount indicator
+3                # /Quantity/i
+bulk             # Label
+7.50             # Price
+                 # Discount indicator
+4                # /Quantity/i
+bulk             # Label
+8.00             # Price
+bonus            # Discount indicator
+0.750kg          # /Quantity/i
+weigh            # Label
+2.50             # Price
+                 # Discount indicator
+1                # /Quantity/i
+due              # Label
+0.89             # Price
+25%              # Discount indicator
+0                # 0 to end products
+disco            # Discount label
+-2.00            # Price decrease
+bulk             # Product
+bulk             # Product
+                 # empty to end "disco"
+over             # Discount label
+-0.22            # Price decrease
+due              # Product
+0                # /Metadata.*0 skips meta/

--- a/samples/new/receipt_valid_input
+++ b/samples/new/receipt_valid_input
@@ -16,6 +16,19 @@ bulk             # Label
 bulk             # Label
 8.00             # Price
 bonus            # Discount indicator
+label            # /More specific metadata .*key/
+                 # Label (empty for "bulk")
+price            # Metadata key
+                 # Price (empty for "2.00")
+                 # Indicator
+discount         # Metadata key
+jazz             # Discount
+brand            # Metadata key
+BigChoc          # /Brand# currently matches but is not saved due to discount/x
+sku              # Metadata key
+abc123           # Shop-specific SKU
+-1               # /Confirm merge by ID \(0.*or negative to add to range\)/
+                 # empty ends this range meta
 0.750kg          # /Quantity/i
 weigh            # Label
 2.50             # Price


### PR DESCRIPTION
- [x] Mention how many discounts have been matched with product items that have discount indicators so far (like product meta, current/total), and skip discount step when all discounted products have been matched
- [x] If there are no further unmatched product items with discount indicators from current "seen" position during discount creation, consider discount step done like when "seen" position is at end
- [x] Argument to allow entering discounts even when it is detected that no more products have discounts, for certain receipt types
- [x] Allow entering product meta when it is detected that all products are matched
- [x] Test for executing command without accepting additional discounts that refer to missing products
- [x] Accept metadata when matches are imperfect or duplicate
- [x] Test for matching product meta without discounts which ends up not matching a product
- [x] Changelog and docs, also about adding product metadata when an item has a duplicate match or if discounts were excluded