### PR TITLE
Add string representation for GTIN

### DIFF
--- a/rechu/types/quantized.py
+++ b/rechu/types/quantized.py
@@ -14,6 +14,12 @@ class GTIN(int):
     Global trade item number identifier for products.
     """
 
+    def __repr__(self) -> str:
+        parts = list(f"{self:_}")
+        # Remove grouping around every other third digit
+        del parts[-4::-8]
+        return "".join(parts)
+
 class Price(Decimal): # pylint: disable=too-few-public-methods
     """
     Price type with scale of 2 (number of decimal places).

--- a/tests/types/quantized.py
+++ b/tests/types/quantized.py
@@ -7,6 +7,21 @@ import unittest
 from rechu.types.quantized import GTIN, Price, GTINType, PriceType
 from .decorator import SerializableTypeTestCase
 
+class GTINTest(unittest.TestCase):
+    """
+    Tests for global trade item number identifier.
+    """
+
+    def test_repr(self) -> None:
+        """
+        Test the string representation of the number.
+        """
+
+        self.assertEqual(repr(GTIN(1234567890)), '1234_567890')
+        self.assertEqual(repr(GTIN(9781234567890)), '9_781234_567890')
+        self.assertEqual(repr(GTIN(0)), '0')
+        self.assertEqual(repr(GTIN(4241929)), '4_241929')
+
 class PriceTest(unittest.TestCase):
     """
     Tests for prices with scale of 2.


### PR DESCRIPTION
Display numbers in groups of 6 digits using underscores between the groups, which means the numbers are still valid in Python.