### PR TITLE
Adjust join depth for product generic/range fields to load other side

### DIFF
--- a/rechu/inventory/products.py
+++ b/rechu/inventory/products.py
@@ -10,7 +10,7 @@ import re
 from string import Formatter
 from typing import Optional
 from sqlalchemy import select
-from sqlalchemy.orm import Session, selectinload
+from sqlalchemy.orm import Session
 from .base import Inventory, Selectors
 from ..io.products import ProductsReader, ProductsWriter, SharedFields, \
     SHARED_FIELDS
@@ -86,8 +86,6 @@ class Products(dict, Inventory[Product]):
 
         for fields in selectors:
             products = session.scalars(select(Product)
-                                       .options(selectinload(Product.range),
-                                                selectinload(Product.generic))
                                        .filter(Product.generic_id.is_(None))
                                        .filter_by(**fields)).all()
             path = data_path / Path(path_format.format(**fields))

--- a/rechu/models/product.py
+++ b/rechu/models/product.py
@@ -58,11 +58,12 @@ class Product(Base): # pylint: disable=too-few-public-methods
     range: Relationship[list["Product"]] = \
         relationship(back_populates="generic", cascade=_CASCADE_OPTIONS,
                      passive_deletes=True, order_by="Product.id",
-                     lazy="selectin")
+                     lazy="selectin", join_depth=2)
     generic_id: MappedColumn[Optional[int]] = \
         mapped_column(ForeignKey(_PRODUCT_REF, ondelete="CASCADE"))
     generic: Relationship[Optional["Product"]] = \
-        relationship(back_populates="range", remote_side=[id], lazy="selectin")
+        relationship(back_populates="range", remote_side=[id], lazy="selectin",
+                     join_depth=2)
 
     def clear(self) -> None:
         """


### PR DESCRIPTION
This avoids some issues from detached models that only have one side of the generic/range relationship loaded.

The default for `join_depth` is 0, which makes it lazy for self-referential relationships, so setting this now removes the need to explicitly set load options in queries, which only happened for the inventory load.