### PR TITLE
New: Correct products in meta view and preserve in receipt edit

### DIFF
--- a/rechu/command/new/__init__.py
+++ b/rechu/command/new/__init__.py
@@ -144,7 +144,7 @@ class New(Base):
                                 more=self.more),
             'view': View(receipt, input_source),
             'write': write,
-            'edit': Edit(receipt, input_source,
+            'edit': Edit(receipt, input_source, matcher=matcher,
                          editor=self.settings.get('data', 'editor')),
             'quit': Quit(receipt, input_source),
             'help': usage,

--- a/rechu/command/new/step/meta.py
+++ b/rechu/command/new/step/meta.py
@@ -314,6 +314,8 @@ class ProductMeta(Step):
         if item is not None:
             LOGGER.info('Receipt product item to match: %r', item)
         else:
+            with Database() as session:
+                self._products.update(self._get_products_meta(session))
             View(self._receipt, self._input, products=self._products).run()
 
         output = self._input.get_output()
@@ -346,7 +348,7 @@ class ProductMeta(Step):
             if item is not None:
                 tmp_file.write(f'# Product to match: {item!r}')
 
-            edit = Edit(self._receipt, self._input)
+            edit = Edit(self._receipt, self._input, self._matcher)
             edit.execute_editor(tmp_file.name)
 
             reader = ProductsReader(tmp_path)

--- a/samples/new/receipt_invalid_input
+++ b/samples/new/receipt_invalid_input
@@ -220,6 +220,7 @@ split               # /Matched metadata can be augmented.*key/i
 !                   # ! cancel
 !                   # /Quantity.*! cancel/
 ?                   # ? to menu
+edit                # Menu
 view                # Menu
 w                   # Menu
 n                   # /Confirm .* write the completed receipt/

--- a/tests/command/new/__init__.py
+++ b/tests/command/new/__init__.py
@@ -442,7 +442,7 @@ class NewTest(DatabaseTestCase):
                 'shop': 'inv',
                 'date': date(2024, 11, 1),
                 'products': [
-                    [1, 'bar', 0.01, '~'],
+                    [1, 'bar', 0.01, '@'],
                     [2, 'xyz', 5.00, '10%'],
                     ['8oz', 'qux', 0.02, 'bonus'],
                     [10, 'bar', 0.10]
@@ -458,7 +458,10 @@ class NewTest(DatabaseTestCase):
         with self._setup_input(Path("samples/new/receipt_invalid_input"),
                                end_inputs=["?", "w", "y"]):
             self.replaces.append(('sku: sp9900', 'sku: sp9999'))
+            self.replaces.append(('candy', 'sweets'))
             self.replaces.append(('1.00', 'oops'))
+            # Receipt edit
+            self.replaces.append(('~', '@'))
             with patch("subprocess.run", side_effect=self._edit_file) as cmd:
                 self._run_command(confirm=True, more=False)
 
@@ -526,4 +529,4 @@ class NewTest(DatabaseTestCase):
                 self._compare_expected_receipt(self.create_invalid,
                                                self.expected_invalid,
                                                matches)
-                self.assertEqual(cmd.call_count, 3)
+                self.assertEqual(cmd.call_count, 4)


### PR DESCRIPTION
- View of metadata items from sequential/menu now always includes earlier created/updated products
- Edit of receipt now brings along matched created/updated products to the items on the newly edited receipt if they still match there, such that they are not lost during write