### PR TITLE
Corrections for updating, matching and splitting products and its ranges

### DIFF
--- a/rechu/command/new/step/meta.py
+++ b/rechu/command/new/step/meta.py
@@ -267,7 +267,7 @@ class ProductMeta(Step):
             setattr(product, key, getattr(product, key))
             setattr(product.generic, key, [])
         elif key in OPTIONAL_FIELDS:
-            setattr(product, key, getattr(product, key))
+            setattr(product, key, getattr(product.generic, key))
             setattr(product.generic, key, None)
         else:
             LOGGER.warning('Unrecognized metadata key %s', key)

--- a/rechu/command/new/step/meta.py
+++ b/rechu/command/new/step/meta.py
@@ -486,10 +486,11 @@ class ProductMeta(Step):
 
         return matcher_attrs
 
+
     def _find_duplicate(self, product: Product) -> Optional[Product]:
         existing = self._matcher.check_map(product)
-        if product.generic is not None and \
-            (existing is None or existing.generic == product):
+        if existing is None and product.generic is not None:
+            # Check if there is a duplicate within the generic product
             matcher = ProductMatcher(map_keys={MapKey.MAP_SKU, MapKey.MAP_GTIN})
             matcher.clear_map()
             for similar in product.generic.range:
@@ -498,12 +499,16 @@ class ProductMeta(Step):
                     return similar if product == clash else clash
                 matcher.add_map(similar)
 
+        if existing is None or existing == product or \
+            existing.generic == product or \
+            (existing.id is not None and existing.id == product.id):
+            return None
+
         return existing
 
     def _check_duplicate(self, product: Product) -> _MetaResult:
         existing = self._find_duplicate(product)
-        while existing is not None and existing != product and \
-                existing.generic != product:
+        while existing is not None:
             LOGGER.warning('Product metadata existing: %r', existing)
             merge_ids = self._generate_merge_ids(existing)
             id_text = ", ".join(merge_ids)

--- a/rechu/command/read.py
+++ b/rechu/command/read.py
@@ -86,9 +86,10 @@ class Read(Base):
                     if existing is None:
                         session.add(product)
                     else:
-                        product.id = existing.id
                         unseen.discard(existing)
-                        session.merge(product)
+                        if existing.merge(product):
+                            product.id = existing.id
+                            session.merge(product)
             except (TypeError, ValueError):
                 self.logger.exception('Could not parse product from %s', path)
 

--- a/rechu/models/product.py
+++ b/rechu/models/product.py
@@ -165,7 +165,7 @@ class Product(Base):
                 LOGGER.debug('Updating field %s from %r to %r', column,
                               current, target)
                 setattr(self, column, target)
-                changed = True
+                changed = changed or not meta.primary_key
 
         return changed
 

--- a/tests/matcher/product.py
+++ b/tests/matcher/product.py
@@ -489,6 +489,14 @@ class ProductMatcherTest(DatabaseTestCase):
                                                 gtin=1234567890123)),
                       self.product)
 
+        far = Product(shop='id',
+                      range=[Product(shop='id'),
+                             Product(shop='id', gtin=9876543210987, sku='def')])
+        matcher.add_map(far)
+        limited.add_map(far)
+        self.assertIs(matcher.check_map(far), far)
+        self.assertIs(limited.check_map(far), far)
+
     def test_find_map(self) -> None:
         """
         Test finding a product in the filled map based on a hash key.

--- a/tests/models/product.py
+++ b/tests/models/product.py
@@ -187,6 +187,11 @@ class ProductTest(DatabaseTestCase):
 
         self.assertFalse(self.product.merge(self.other))
 
+        less = Product(shop='id')
+        more = Product(shop='id', id=3)
+        self.assertFalse(less.merge(more))
+        self.assertEqual(less.id, 3)
+
         with self.assertRaisesRegex(ValueError, ".*shop.*"):
             self.assertFalse(self.product.merge(Product(shop='other')))
 


### PR DESCRIPTION
- New: Correct split range identifiers keys
- New: Meta from existing product should not suggest merging with itself
- Read: Do not update products without changes
- Product matcher: Attempt finding "empty" products by product range keys
- Product: Do not consider only ID merge as update