### PR TITLE
New: Improve meta augmentation, splitting and discard/refresh operations

### DIFF
--- a/rechu/command/new/step/meta.py
+++ b/rechu/command/new/step/meta.py
@@ -140,12 +140,24 @@ class ProductMeta(Step):
                                                   changed=False)
         while not matched:
             changed = initial_product.copy().merge(product)
-            if not changed or initial_key in {'0', '!'}:
+            if initial_key == '!':
+                LOGGER.info('Discarded changes to start with fresh product')
+                product.clear()
+                product.merge(initial_product)
+                existing = False
+                changed = False
+                product = Product(shop=self._receipt.shop)
+                initial_product = product.copy()
+            elif not changed or initial_key == '0':
                 if existing:
+                    product.clear()
+                    product.merge(initial_product)
                     LOGGER.info('Product %r was not updated', product)
                 return False, initial_key
+            else:
+                LOGGER.warning('Product %r does not match receipt item',
+                               product)
 
-            LOGGER.warning('Product %r does not match receipt item', product)
             initial_key = self._get_key(product, item=item,
                                         initial_changed=changed)
             if initial_key == '':
@@ -177,11 +189,11 @@ class ProductMeta(Step):
                       initial_key: Optional[str] = None,
                       changed: bool = False) \
             -> tuple[set[ProductItem], Optional[str]]:
-        initial_key = self._set_values(product, item=item,
-                                       initial_key=initial_key, changed=changed)
-        if initial_key in {'', '!'}:
+        key = self._set_values(product, item=item, initial_key=initial_key,
+                               changed=changed)
+        if key in {'', '!'} or (item is not None and key == '0'):
             # Canceled creation/merged with already-matched product
-            return set(), initial_key
+            return set(), key
 
         items = self._receipt.products if item is None else [item]
         matched = set()
@@ -204,7 +216,7 @@ class ProductMeta(Step):
                     else:
                         LOGGER.info('Matched with item: %r', match)
 
-        return matched, initial_key
+        return matched, key
 
     def _set_values(self, product: Product, item: Optional[ProductItem] = None,
                     initial_key: Optional[str] = None,
@@ -296,9 +308,7 @@ class ProductMeta(Step):
                     split_range = product_range.copy()
                     split_range.generic = None
             if split_key == '!':
-                product_range.generic = None
-                product.merge(product_range)
-                return False, '', False
+                return True, split_key, False
 
         initial_key = self._set_values(product_range, item=item,
                                        changed=split_range is not None)

--- a/rechu/command/new/step/meta.py
+++ b/rechu/command/new/step/meta.py
@@ -249,6 +249,7 @@ class ProductMeta(Step):
     @staticmethod
     def _get_initial_range(product: Product) -> Product:
         initial = product.copy()
+        initial.id = None
         initial.range = []
         for field in IDENTIFIER_FIELDS:
             setattr(initial, field, None)

--- a/samples/new/receipt_invalid_input
+++ b/samples/new/receipt_invalid_input
@@ -79,7 +79,7 @@ candy               # Category
 range               # Metadata key
 range               # /Metadata key.*range meta/
 0                   # 0 skips range meta
-0                   # 0 discards meta
+                    # empty ends this meta
 2                   # /Quantity/i
 xyz                 # Label
 5.00                # Price
@@ -217,8 +217,18 @@ bar                 # Label
 0.31                # Price
                     # Discount indicator
 split               # /Matched metadata can be augmented.*key/i
+discount            # Metadata key
 !                   # ! cancel
+0                   # 0 skips meta
 !                   # /Quantity.*! cancel/
+33                  # /Quantity/i
+bar                 # Label
+0.33                # Price
+                    # Discount indicator
+sku                 # /Matched metadata can be augmented.*key/i
+test                # Shop-specific SKU
+0                   # 0 discards meta
+!                   # ! cancel
 ?                   # ? to menu
 edit                # Menu
 view                # Menu

--- a/tests/command/new/__init__.py
+++ b/tests/command/new/__init__.py
@@ -19,7 +19,7 @@ from rechu.command.new import New, InputSource, Prompt, Step
 from rechu.inventory.products import Products
 from rechu.io.products import ProductsReader, ProductsWriter
 from rechu.io.receipt import ReceiptReader
-from rechu.models.base import Price, Quantity
+from rechu.models.base import GTIN, Price, Quantity
 from rechu.models.product import Product, LabelMatch, PriceMatch, DiscountMatch
 from rechu.models.receipt import Receipt, ProductItem
 from rechu.models.shop import Shop
@@ -374,7 +374,7 @@ class NewTest(DatabaseTestCase):
                                 labels=[LabelMatch(name='unmatched')],
                                 prices=[PriceMatch(value=Price('9.87'))],
                                 sku='zz123',
-                                gtin=5555555555555))
+                                gtin=GTIN(5555555555555)))
 
         with self._setup_input(Path("samples/new/receipt_input")):
             self._run_command()
@@ -509,7 +509,7 @@ class NewTest(DatabaseTestCase):
                                    portions=9,
                                    weight=Quantity('450g'),
                                    sku='sp900',
-                                   gtin=4321987654321)
+                                   gtin=GTIN(4321987654321))
                     base.range = [
                         # First range product (car)
                         # Override price matchers


### PR DESCRIPTION
- Avoid UNIQUE constraint violation errors from augment split with existing product meta
- Correct propagation of 0 and ! in meta substeps like split and
  settings values for a specific item (discard changes as mentioned by
  message)
- Actually discard changes for existing products
- Differentiate 0 and ! by letting ! continue with a fresh, new product. Thus,
  when existing metadata matched, allow creating an entirely new metadata with
  more specific matchers