### PR TITLE
Meta: Month precision in price matcher indicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and we adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Allow product metadata price matchers to only match product items on receipts 
+  from a specific year and month combination, by formatting the year and month 
+  in the indicator with a dash in between.
 - Allow product metadata label and discount matchers to contain regular 
   expressions starting with a caret (`^`) which matches product items no other 
   metadata matches.

--- a/docs/source/files.md
+++ b/docs/source/files.md
@@ -106,9 +106,9 @@ product items, we use *matchers*:
   prices in the list. Otherwise, the matchers for prices is an object with 
   keys, which could define a range using minimum and maximum prices (again 
   using the normalized price to compare with both interval ends required), 
-  prices per year key (with a similar comparison) or prices for a particular 
-  unit (using the normalized format for units as keys, such as 'kilogram' and 
-  not 'kg').
+  prices for a particular unit (using the normalized format for units as keys, 
+  such as 'kilogram' and not 'kg') or prices in a specific year or year-month 
+  combination (using the normalized price).
 - For discounts, we match the labels of any of the discounts that a product is 
   involved in (so not the discount indicator provided directly with the item) 
   with any of the names in the list.

--- a/rechu/command/new/step/meta.py
+++ b/rechu/command/new/step/meta.py
@@ -124,10 +124,13 @@ class ProductMeta(Step):
             min_date = session.scalar(select(min_(Receipt.date)))
             if min_date is None:
                 min_date = self.receipt.date
-            years = range(min_date.year, date.today().year + 1)
+            today = date.today()
+            years = range(min_date.year, today.year + 1)
+            months = range(1, today.month + 1)
             self.input.update_suggestions(
                 {
                     "indicators": [str(year) for year in years]
+                    + [f"{today.year}-{month:0>2}" for month in months]
                     + [Indicator.MINIMUM.value, Indicator.MAXIMUM.value]
                     + [
                         str(product.unit)

--- a/tests/matcher/product.py
+++ b/tests/matcher/product.py
@@ -181,6 +181,14 @@ class ProductMatcherTest(DatabaseTestCase):
             fake_year = Product(
                 shop="id", prices=[PriceMatch(value="2.50", indicator="2014")]
             )
+            fake_month = Product(
+                shop="id",
+                prices=[PriceMatch(value="2.50", indicator="2024-12")],
+            )
+            fake_month_pad = Product(
+                shop="id",
+                prices=[PriceMatch(value="2.50", indicator="2024-011")],
+            )
             fake_discount = Product(
                 shop="id", discounts=[DiscountMatch(label="foobar")]
             )
@@ -200,6 +208,8 @@ class ProductMatcherTest(DatabaseTestCase):
                     MagicMock(Product=fake_range, ProductItem=items[1]),
                     MagicMock(Product=fake_open_range, ProductItem=items[1]),
                     MagicMock(Product=fake_year, ProductItem=items[1]),
+                    MagicMock(Product=fake_month, ProductItem=items[1]),
+                    MagicMock(Product=fake_month_pad, ProductItem=items[1]),
                     MagicMock(Product=fake_discount, ProductItem=items[1]),
                 ]
             }
@@ -440,6 +450,11 @@ class ProductMatcherTest(DatabaseTestCase):
                 Price("1.23"),
                 one,
             ),
+            (
+                [PriceMatch(value=Price("1.23"), indicator="2024-11")],
+                Price("1.23"),
+                one,
+            ),
             ([PriceMatch(value=Price("2.00"))], Price("2.00"), Quantity("2")),
             (
                 [PriceMatch(value=Price("1.00"), indicator="kilogram")],
@@ -602,6 +617,26 @@ class ProductMatcherTest(DatabaseTestCase):
                     label="due",
                     price=Price("1.00"),
                     discounts=[Discount(receipt=receipt, label="?over")],
+                    amount=one.amount,
+                    unit=one.unit,
+                ),
+            )
+        )
+
+        # Price matchers with zero-padded months work properly.
+        self.assertTrue(
+            matcher.match(
+                Product(
+                    shop="id",
+                    prices=[
+                        PriceMatch(value=Price("1.23"), indicator="2025-05")
+                    ],
+                ),
+                ProductItem(
+                    receipt=receipt,
+                    quantity=one,
+                    label="test",
+                    price=Price("1.23"),
                     amount=one.amount,
                     unit=one.unit,
                 ),


### PR DESCRIPTION
Allow product metadata price matchers to only match product items on receipts from a specific year and month combination, by formatting the year and month in the indicator with a dash in between.