### PR TITLE
Write: Save product updates to YAML inventory and improve merge and edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and we adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Allow product metadata range to be created or updated when the parent generic 
+  product or sibling range products match, but only when the range product also
+  matches but is simply overshadowed by its siblings.
 - Allow product metadata review and edit after all receipt products are matched
   and the `--more` argument was not used for the `new` subcommand.
 - Indicate if pending product metadata that is not matching any products on the 
@@ -29,6 +32,9 @@ and we adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Edited existing products are no longer lost during matching to receipt items 
+  due to overshadows of existing products in `new` subcommand.
+- Do not lose changes to existing product metadata in `new` subcommand.
 - Do not lose pending product metadata where a range product matches after edit 
   of receipt in `new` subcommand.
 - Do not lose pending product metadata after edit of multiple products in `new` 

--- a/rechu/command/new/__init__.py
+++ b/rechu/command/new/__init__.py
@@ -187,7 +187,8 @@ class New(Base):
         matcher = ProductMatcher()
         matcher.discounts = False
 
-        with Database() as session:
+        database = Database()
+        with database as session:
             self._load_suggestions(session, input_source)
 
             receipt_date = input_source.get_date(
@@ -204,23 +205,45 @@ class New(Base):
             date=receipt_date.date(),
             shop=shop,
         )
-        write = Write(receipt, input_source, matcher=matcher)
+        write = Write(
+            receipt=receipt,
+            input=input_source,
+            database=database,
+            matcher=matcher,
+        )
         write.path = path
         usage = Help(receipt, input_source)
         menu: Menu = {
-            "read": Read(receipt, input_source, matcher=matcher),
-            "products": Products(receipt, input_source, matcher=matcher),
+            "read": Read(
+                receipt=receipt,
+                input=input_source,
+                database=database,
+                matcher=matcher,
+            ),
+            "products": Products(
+                receipt=receipt,
+                input=input_source,
+                database=database,
+                matcher=matcher,
+            ),
             "discounts": Discounts(
                 receipt, input_source, matcher=matcher, more=self.more
             ),
             "meta": ProductMeta(
-                receipt, input_source, matcher=matcher, more=self.more
+                receipt=receipt,
+                input=input_source,
+                database=database,
+                matcher=matcher,
+                more=self.more,
             ),
-            "view": View(receipt, input_source),
+            "view": View(
+                receipt=receipt, input=input_source, database=database
+            ),
             "write": write,
             "edit": Edit(
-                receipt,
-                input_source,
+                receipt=receipt,
+                input=input_source,
+                database=database,
                 matcher=matcher,
                 editor=self.settings.get("data", "editor"),
             ),

--- a/rechu/command/new/step/base.py
+++ b/rechu/command/new/step/base.py
@@ -13,6 +13,8 @@ from sqlalchemy import inspect
 from sqlalchemy.orm import Session
 from typing_extensions import TypedDict
 
+from rechu.database import Database
+
 from ....io.products import ProductsWriter, SharedFields
 from ....models.product import Product
 from ....models.receipt import ProductItem, Receipt
@@ -148,3 +150,12 @@ class Step(metaclass=ABCMeta):
         """
 
         return False
+
+
+@dataclass
+class DatabaseStep(Step, metaclass=ABCMeta):
+    """
+    A receipt creation step that needs to access the database.
+    """
+
+    database: Database

--- a/rechu/command/new/step/base.py
+++ b/rechu/command/new/step/base.py
@@ -64,19 +64,25 @@ class Step(metaclass=ABCMeta):
 
         raise NotImplementedError("Step must be implemented by subclasses")
 
+    @staticmethod
+    def _get_root_product(product: Product) -> Product:
+        return product if product.generic is None else product.generic
+
+    @staticmethod
+    def _is_modified_product(product: Product, session: Session) -> bool:
+        return (
+            cast(int | None, product.id) is None
+            or product in session.dirty
+            or inspect(product).modified
+        )
+
     def _get_products_meta(self, session: Session) -> set[Product]:
         # Retrieve new/updated product metadata associated with receipt items
         return {
-            item.product
-            if item.product.generic is None
-            else item.product.generic
+            self._get_root_product(item.product)
             for item in self.receipt.products
             if item.product is not None
-            and (
-                cast(int | None, item.product.id) is None
-                or item.product in session.dirty
-                or inspect(item.product).modified
-            )
+            and self._is_modified_product(item.product, session)
         }
 
     def _clear_products_meta(self) -> None:
@@ -93,6 +99,7 @@ class Step(metaclass=ABCMeta):
         return {
             product
             for product in unmatched
+            # Check if the product is not empty
             if Product(shop=product.shop).merge(product)
         }
 
@@ -117,7 +124,7 @@ class Step(metaclass=ABCMeta):
             products_writer = ProductsWriter(
                 Path("products.yml"),
                 [
-                    product.generic if product.generic is not None else product
+                    self._get_root_product(product)
                     for product in products
                     if product.generic not in generic_products
                 ],

--- a/rechu/command/new/step/edit.py
+++ b/rechu/command/new/step/edit.py
@@ -12,17 +12,16 @@ from pathlib import Path
 
 from typing_extensions import override
 
-from ....database import Database
 from ....io.receipt import ReceiptReader, ReceiptWriter
 from ....matcher.product import ProductMatcher
 from ....models.receipt import Receipt
-from .base import ResultMeta, ReturnToMenu, Step
+from .base import DatabaseStep, ResultMeta, ReturnToMenu
 
 LOGGER = logging.getLogger(__name__)
 
 
 @dataclass
-class Edit(Step):
+class Edit(DatabaseStep):
     """
     Step to edit the receipt in its YAML representation via a temporary file.
     """
@@ -63,7 +62,7 @@ class Edit(Step):
             return {"receipt_path": update_path}
 
     def _update_matches(self, receipt: Receipt) -> None:
-        with Database() as session:
+        with self.database as session:
             products = self._get_products_meta(session)
             pairs = self.matcher.find_candidates(
                 session, receipt.products, products

--- a/rechu/command/new/step/meta.py
+++ b/rechu/command/new/step/meta.py
@@ -15,7 +15,6 @@ from sqlalchemy import select
 from sqlalchemy.sql.functions import min as min_
 from typing_extensions import Required, TypedDict, override
 
-from ....database import Database
 from ....io.products import (
     IDENTIFIER_FIELDS,
     OPTIONAL_FIELDS,
@@ -34,7 +33,7 @@ from ....models.product import (
 )
 from ....models.receipt import ProductItem, Receipt
 from ..input import Input
-from .base import ResultMeta, ReturnToMenu, Step
+from .base import DatabaseStep, ResultMeta, ReturnToMenu
 from .edit import Edit
 from .view import View
 
@@ -74,7 +73,7 @@ MATCHERS: dict[str, _Matcher] = {
 
 
 @dataclass
-class ProductMeta(Step):
+class ProductMeta(DatabaseStep):
     """
     Step to add product metadata that matches one or more products.
     """
@@ -93,7 +92,7 @@ class ProductMeta(Step):
             return {}
 
         # Check if there are any unmatched products on the receipt
-        with Database() as session:
+        with self.database as session:
             self.products.update(self._get_products_meta(session))
             candidates = self.matcher.find_candidates(
                 session, self.receipt.products, self.products
@@ -125,7 +124,7 @@ class ProductMeta(Step):
         return {}
 
     def _load_suggestions(self) -> None:
-        with Database() as session:
+        with self.database as session:
             min_date = session.scalar(select(min_(Receipt.date)))
             if min_date is None:
                 min_date = self.receipt.date
@@ -236,7 +235,7 @@ class ProductMeta(Step):
 
         items = self.receipt.products if item is None else [item]
         matched: set[ProductItem] = set()
-        with Database() as session:
+        with self.database as session:
             self.products.update(self._get_products_meta(session))
             matchers = set(product.range)
             matchers.add(product)
@@ -408,9 +407,14 @@ class ProductMeta(Step):
         if item is not None:
             LOGGER.info("Receipt product item to match: %r", item)
         else:
-            with Database() as session:
+            with self.database as session:
                 self.products.update(self._get_products_meta(session))
-            _ = View(self.receipt, self.input, products=self.products).run()
+            _ = View(
+                receipt=self.receipt,
+                input=self.input,
+                database=self.database,
+                products=self.products,
+            ).run()
 
         output = self.input.get_output()
         print(file=output)
@@ -459,7 +463,7 @@ class ProductMeta(Step):
             if item is not None:
                 _ = tmp_file.write(f"# Product to match: {item!r}")
 
-            edit = Edit(self.receipt, self.input, self.matcher)
+            edit = Edit(self.receipt, self.input, self.database, self.matcher)
             edit.execute_editor(tmp_file.name)
 
             reader = ProductsReader(tmp_path)
@@ -488,7 +492,7 @@ class ProductMeta(Step):
         for extra_product in extra_products:
             _ = self.matcher.add_map(extra_product, True)
 
-        with Database() as session:
+        with self.database as session:
             originals = {item: item.product for item in self.receipt.products}
             self._clear_products_meta()
 

--- a/rechu/command/new/step/meta.py
+++ b/rechu/command/new/step/meta.py
@@ -177,7 +177,7 @@ class ProductMeta(Step):
             product, item=item, initial_key=initial_key, changed=False
         )
         while not matched:
-            changed = initial_product.copy().merge(product)
+            changed = not initial_product.equals(product)
             if initial_key == "!":
                 LOGGER.info("Discarded changes to start with fresh product")
                 _ = product.replace(initial_product)
@@ -203,7 +203,7 @@ class ProductMeta(Step):
                 product, item=item, initial_key=initial_key, changed=changed
             )
 
-        changed = initial_product.copy().merge(product)
+        changed = not initial_product.equals(product)
         if not changed:
             # Should always be existing otherwise it would not match
             LOGGER.info("Product %r remained the same", product)
@@ -213,7 +213,7 @@ class ProductMeta(Step):
         LOGGER.info(
             "Product %s: %r", "updated" if existing else "created", product
         )
-        self.products.add(product)
+        self.products.add(self._get_root_product(product))
         _ = self.matcher.add_map(product)
         if matched_items is not None:
             matched_items.update(matched)
@@ -240,14 +240,17 @@ class ProductMeta(Step):
             self.products.update(self._get_products_meta(session))
             matchers = set(product.range)
             matchers.add(product)
-            if product.generic is not None:
-                matchers.add(product.generic)
+            generic = self._get_root_product(product)
+            matchers.add(generic)
+            matchers.update(generic.range)
 
             pairs = self.matcher.find_candidates(
                 session, items, self.products | matchers
             )
             for meta, match in self.matcher.filter_duplicate_candidates(pairs):
-                if meta in matchers:
+                # Only accept the match if the current product also matches,
+                # but might be overshadowed by generic or sibling range.
+                if meta in matchers and self.matcher.match(product, match):
                     match.product = meta
                     matched.add(match)
                     if not match.discounts and product.discounts:
@@ -256,9 +259,10 @@ class ProductMeta(Step):
                         )
                     else:
                         LOGGER.info("Matched with item: %r", match)
+            self.products.add(self._get_root_product(product))
             self._view_products_meta(
                 "Products that no longer match:",
-                self._update_products_meta(session, self.products | {product}),
+                self._update_products_meta(session, self.products),
             )
 
         return matched, key
@@ -387,7 +391,7 @@ class ProductMeta(Step):
         initial_key = self._set_values(
             product_range, item=item, changed=split_range is not None
         )
-        if initial_key == "" or not initial.merge(product_range):
+        if initial_key == "" or initial.equals(product_range):
             product_range.generic = None
             if split_range is not None:
                 _ = product.merge(split_range)
@@ -441,8 +445,7 @@ class ProductMeta(Step):
         products: tuple[Product, ...] = ()
         if item is None:
             products = tuple(
-                existing if existing.generic is None else existing.generic
-                for existing in self.products
+                self._get_root_product(existing) for existing in self.products
             )
         if product is not None:
             if (product_generic := product.generic) is not None:
@@ -483,9 +486,10 @@ class ProductMeta(Step):
     def _edit_extra_products(self, extra_products: tuple[Product, ...]) -> None:
         products = self.products | set(extra_products)
         for extra_product in extra_products:
-            _ = self.matcher.add_map(extra_product)
+            _ = self.matcher.add_map(extra_product, True)
 
         with Database() as session:
+            originals = {item: item.product for item in self.receipt.products}
             self._clear_products_meta()
 
             candidates = self.matcher.find_candidates(
@@ -493,13 +497,14 @@ class ProductMeta(Step):
                 self.receipt.products,
                 extra_products,
             )
-            pairs = self.matcher.filter_duplicate_candidates(candidates)
+            pairs = self.matcher.filter_duplicate_candidates(
+                candidates, extra_products
+            )
             for candidate, target in pairs:
-                if (
-                    candidate in products
-                    or candidate.generic in products
-                    or cast(int | None, candidate.id) is None
-                ):
+                new = self._get_root_product(candidate)
+                if new in products or cast(int | None, candidate.id) is None:
+                    if original := originals.get(target):
+                        new.id = self._get_root_product(original).id
                     LOGGER.info("Matching %r to %r", target, candidate)
                     target.product = candidate
 
@@ -515,12 +520,14 @@ class ProductMeta(Step):
             range_index = generic.range.index(product)
             _ = generic.replace(new_product)
             _ = product.replace(generic.range[range_index])
-            generic.range[range_index] = product
-            _ = self.matcher.add_map(generic)
+            product.generic = generic
+            generic.range[range_index:] = [product]
+            _ = self.matcher.add_map(product, True)
+            _ = self.matcher.add_map(generic, True)
         else:
             setattr(new_product, "id", product.id)
             _ = product.replace(new_product)
-            _ = self.matcher.add_map(product)
+            _ = self.matcher.add_map(product, True)
 
     def _get_key(
         self,

--- a/rechu/command/new/step/products.py
+++ b/rechu/command/new/step/products.py
@@ -6,7 +6,7 @@ import logging
 import re
 from dataclasses import dataclass
 
-from sqlalchemy import select
+from sqlalchemy import inspect, select
 from sqlalchemy.sql.functions import count
 from typing_extensions import override
 
@@ -196,10 +196,10 @@ class Products(Step):
 
     def _desessionate(self, product: Product) -> Product | None:
         desessionated = self.matcher.check_map(product)
-        if desessionated is not None and desessionated.generic is not None:
-            return desessionated.generic
-
-        return desessionated
+        generic = self._get_root_product(
+            desessionated if desessionated is not None else product
+        )
+        return generic if inspect(generic).session is None else None
 
     def _make_meta(
         self, item: ProductItem, prompt: str, pairs: Pairs, dedupe: Pairs

--- a/rechu/command/new/step/products.py
+++ b/rechu/command/new/step/products.py
@@ -5,29 +5,32 @@ Products step of new subcommand.
 import logging
 import re
 from dataclasses import dataclass
+from typing import ClassVar
 
 from sqlalchemy import inspect, select
 from sqlalchemy.sql.functions import count
 from typing_extensions import override
 
-from ....database import Database
 from ....matcher.product import ProductMatcher
 from ....models.base import Price, Quantity
 from ....models.product import Product
 from ....models.receipt import ProductItem
-from .base import Pairs, ResultMeta, ReturnToMenu, Step
+from .base import DatabaseStep, Pairs, ResultMeta, ReturnToMenu
 from .meta import ProductMeta
 
 LOGGER = logging.getLogger(__name__)
 
 
 @dataclass
-class Products(Step):
+class Products(DatabaseStep):
     """
     Step to add products.
     """
 
     matcher: ProductMatcher
+    PROMPT: ClassVar[str] = (
+        "Quantity (empty or 0 to end products, ? to menu, ! cancels)"
+    )
 
     @override
     def run(self) -> ResultMeta:
@@ -45,21 +48,20 @@ class Products(Step):
         Request fields for a product and add it to the receipt.
         """
 
-        prompt = "Quantity (empty or 0 to end products, ? to menu, ! cancels)"
         if self.receipt.products and not first:
             previous = self.receipt.products[-1]
             # Check if the previous product item has a product metadata match
             # If not, we might want to create one right now
-            with Database() as session:
+            with self.database as session:
                 pairs = tuple(
                     self.matcher.find_candidates(
                         session, (previous,), self._get_products_meta(session)
                     )
                 )
-                dedupe = tuple(self.matcher.filter_duplicate_candidates(pairs))
-                amount = self._make_meta(previous, prompt, pairs, dedupe)
+                product, match_prompt = self._make_meta_prompt(pairs)
+            amount = self._make_meta(previous, product, match_prompt)
         else:
-            amount = self.input.get_input(prompt, str)
+            amount = self.input.get_input(self.PROMPT, str)
 
         if amount in {"", "0"}:
             return False
@@ -109,7 +111,7 @@ class Products(Step):
         return True
 
     def _update_suggestions(self, label: str) -> None:
-        with Database() as session:
+        with self.database as session:
             prices = session.scalars(
                 select(ProductItem.price)
                 .where(ProductItem.label == label)
@@ -155,11 +157,10 @@ class Products(Step):
 
         return False
 
-    def _make_meta_prompt(
-        self, pairs: Pairs, dedupe: Pairs
-    ) -> tuple[Product | None, str]:
+    def _make_meta_prompt(self, pairs: Pairs) -> tuple[Product | None, str]:
         match_prompt = "No metadata yet"
         product: Product | None = None
+        dedupe = tuple(self.matcher.filter_duplicate_candidates(pairs))
         if dedupe:
             if not self.matcher.discounts and dedupe[0][0].discounts:
                 LOGGER.info(
@@ -202,14 +203,20 @@ class Products(Step):
         return generic if inspect(generic).session is None else None
 
     def _make_meta(
-        self, item: ProductItem, prompt: str, pairs: Pairs, dedupe: Pairs
+        self,
+        item: ProductItem,
+        product: Product | None,
+        match_prompt: str,
     ) -> str | Quantity:
-        product, match_prompt = self._make_meta_prompt(pairs, dedupe)
-
         add_product = True
         while add_product:
-            meta_prompt = f"{match_prompt}. Next {prompt.lower()} or key"
-            meta = ProductMeta(self.receipt, self.input, matcher=self.matcher)
+            meta_prompt = f"{match_prompt}. Next {self.PROMPT.lower()} or key"
+            meta = ProductMeta(
+                receipt=self.receipt,
+                input=self.input,
+                database=self.database,
+                matcher=self.matcher,
+            )
             key = meta.get_choice(
                 meta_prompt,
                 options=[] if product is None else ["range", "split"],
@@ -222,7 +229,7 @@ class Products(Step):
                 item=item, initial_key=key, product=product
             )[0]
 
-        return self.input.get_input(prompt, str)
+        return self.input.get_input(self.PROMPT, str)
 
     @property
     @override

--- a/rechu/command/new/step/read.py
+++ b/rechu/command/new/step/read.py
@@ -11,19 +11,18 @@ from sqlalchemy import select
 from sqlalchemy.orm import MappedColumn, Session
 from typing_extensions import override
 
-from ....database import Database
 from ....inventory import Inventory
 from ....inventory.products import Products as ProductInventory
 from ....inventory.shops import Shops
 from ....matcher.product import ProductMatcher
 from ....models import Product, Shop
-from .base import ResultMeta, Step
+from .base import DatabaseStep, ResultMeta
 
 LOGGER = logging.getLogger(__name__)
 
 
 @dataclass
-class Read(Step):
+class Read(DatabaseStep):
     """
     Step to check if there are any new or updated product metadata entries in
     the file inventory that should be synchronized with the database inventory
@@ -34,7 +33,7 @@ class Read(Step):
 
     @override
     def run(self) -> ResultMeta:
-        with Database() as session:
+        with self.database as session:
             session.expire_on_commit = False
 
             # Synchronize updated shop metadata

--- a/rechu/command/new/step/view.py
+++ b/rechu/command/new/step/view.py
@@ -7,14 +7,13 @@ from pathlib import Path
 
 from typing_extensions import override
 
-from ....database import Database
 from ....io.receipt import ReceiptWriter
 from ....models.product import Product
-from .base import ResultMeta, Step
+from .base import DatabaseStep, ResultMeta
 
 
 @dataclass
-class View(Step):
+class View(DatabaseStep):
     """
     Step to display the receipt in its YAML representation.
     """
@@ -36,7 +35,7 @@ class View(Step):
         if self.products is not None:
             products = self.products
         else:
-            with Database() as session:
+            with self.database as session:
                 products = self._get_products_meta(session)
 
         self._view_products_meta("Prepared product metadata:", products)

--- a/rechu/command/new/step/write.py
+++ b/rechu/command/new/step/write.py
@@ -10,13 +10,12 @@ from typing import TypeVar
 from sqlalchemy import select
 from typing_extensions import override
 
-from ....database import Database
 from ....inventory.products import Products as ProductInventory
 from ....io.base import Writer
 from ....io.receipt import ReceiptWriter
 from ....matcher.product import ProductMatcher
 from ....models import Base as ModelBase, Shop
-from .base import ResultMeta, ReturnToMenu, Step
+from .base import DatabaseStep, ResultMeta, ReturnToMenu
 
 LOGGER = logging.getLogger(__name__)
 
@@ -24,7 +23,7 @@ T = TypeVar("T", bound=ModelBase)
 
 
 @dataclass
-class Write(Step):
+class Write(DatabaseStep):
     """
     Final step to write the receipt to a YAML file and store in the database.
     """
@@ -54,7 +53,7 @@ class Write(Step):
             raise ReturnToMenu("No products added to receipt")
 
         self._write(ReceiptWriter(self.path, (self.receipt,)))
-        with Database() as session:
+        with self.database as session:
             self.matcher.discounts = True
             products = self._get_products_meta(session)
             self._clear_products_meta()

--- a/rechu/database.py
+++ b/rechu/database.py
@@ -10,7 +10,7 @@ from typing import TextIO
 from alembic import script
 from alembic.config import Config
 from alembic.runtime.migration import MigrationContext
-from sqlalchemy import create_engine, event
+from sqlalchemy import Pool, create_engine, event
 from sqlalchemy.engine import Engine
 from sqlalchemy.engine.interfaces import DBAPIConnection
 from sqlalchemy.orm import Session
@@ -25,9 +25,11 @@ class Database:
     Database provider.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, pool: Pool | None = None) -> None:
         settings = Settings.get_settings()
-        self.engine: Engine = create_engine(settings.get("database", "uri"))
+        self.engine: Engine = create_engine(
+            settings.get("database", "uri"), pool=pool
+        )
         self.session: Session | None = None
 
         if self.engine.name == "sqlite":

--- a/rechu/inventory/shops.py
+++ b/rechu/inventory/shops.py
@@ -119,7 +119,6 @@ class Shops(Inventory[Shop], dict[Path, list[Shop]]):
                 existing = existing.copy()
             if existing.merge(shop):
                 changed = True
-
             updates.append(existing)
 
         if update:

--- a/rechu/matcher/base.py
+++ b/rechu/matcher/base.py
@@ -50,18 +50,26 @@ class Matcher(Generic[IT, CT], metaclass=ABCMeta):
         raise NotImplementedError("Search must be implemented by subclasses")
 
     def filter_duplicate_candidates(
-        self, candidates: Iterable[tuple[CT, IT]]
+        self,
+        candidates: Iterable[tuple[CT, IT]],
+        preferred: Collection[CT] = (),
     ) -> Iterator[tuple[CT, IT]]:
         """
         Detect if item models were matched against multiple candidates and
-        filter out such models.
+        filter out such models. If preferred candidate models are provided, then
+        any match with such candidates may only be filtered out if other matches
+        are also with preferred candidate models.
         """
 
         seen: dict[IT, CT | None] = {}
+        preferred_candidates = frozenset(preferred)
         for candidate, item in candidates:
-            if item in seen:
+            previous = seen.get(item, False)
+            previous_preferred = previous in preferred_candidates
+            new_preferred = candidate in preferred_candidates
+            if previous is not False and previous_preferred == new_preferred:
                 seen[item] = self.select_duplicate(candidate, seen[item])
-            else:
+            elif not previous_preferred:
                 seen[item] = candidate
         for item, unique in seen.items():
             if unique is not None:
@@ -140,11 +148,12 @@ class Matcher(Generic[IT, CT], metaclass=ABCMeta):
             for model in group:
                 _ = self.add_map(model)
 
-    def add_map(self, candidate: CT) -> bool:
+    def add_map(self, candidate: CT, replace: bool = False) -> bool:
         """
         Manually add a candidate model to a mapping of unique keys. Returns
-        whether the entity was actually added, which is not done if the map is
-        not initialized or the keys are not unique enough.
+        whether the entity was actually added. If the map is not initialized,
+        the candidate is never added. If a key is not unique enough and
+        `replace` is disabled, then that key is not given the new candidate.
         """
 
         if self._map is None:
@@ -152,7 +161,11 @@ class Matcher(Generic[IT, CT], metaclass=ABCMeta):
 
         add = False
         for key in self.get_keys(candidate):
-            add = self._map.setdefault(key, candidate) is candidate or add
+            if replace:
+                self._map[key] = candidate
+                add = True
+            else:
+                add = self._map.setdefault(key, candidate) is candidate or add
 
         return add
 

--- a/rechu/matcher/product.py
+++ b/rechu/matcher/product.py
@@ -516,11 +516,11 @@ class ProductMatcher(Matcher[ProductItem, Product]):
         return session.scalars(self._build_candidate_query(exclude)).all()
 
     @override
-    def add_map(self, candidate: Product) -> bool:
+    def add_map(self, candidate: Product, replace: bool = False) -> bool:
         if self._map is None:
             return False
 
-        add = super().add_map(candidate)
+        add = super().add_map(candidate, replace)
 
         for product_range in candidate.range:
             add = self.add_map(product_range) or add

--- a/rechu/models/product.py
+++ b/rechu/models/product.py
@@ -105,6 +105,54 @@ class Product(Base):
         back_populates="range", remote_side=[id], lazy="selectin", join_depth=2
     )
 
+    def equals(self, other: "Product") -> bool:
+        """
+        Determine whether this product has the exact same fields as the other
+        product. Primary keys and foreign key IDs are ignored, but fields are
+        compared deeply.
+        """
+
+        try:
+            if (
+                any(
+                    not label.equals(other_label)
+                    for label, other_label in zip(
+                        self.labels, other.labels, strict=True
+                    )
+                )
+                or any(
+                    not price.equals(other_price)
+                    for price, other_price in zip(
+                        self.prices, other.prices, strict=True
+                    )
+                )
+                or any(
+                    not discount.equals(other_discount)
+                    for discount, other_discount in zip(
+                        self.discounts, other.discounts, strict=True
+                    )
+                )
+                or any(
+                    not range_product.equals(other_range)
+                    for range_product, other_range in zip(
+                        self.range, other.range, strict=True
+                    )
+                )
+            ):
+                return False
+        except ValueError:
+            return False
+
+        for column, meta in self.__table__.c.items():
+            if (
+                not meta.primary_key
+                and not meta.foreign_keys
+                and getattr(self, column, None) != getattr(other, column, None)
+            ):
+                return False
+
+        return True
+
     def clear(self) -> None:
         """
         Remove all matchers, properties, identifiers and range products, but
@@ -352,6 +400,9 @@ class Product(Base):
         shop identifier (which must be the same) and the matchers (where unique
         matchers from the other product are added).
 
+        If the other product is missing a field, then it is not deleted from
+        this merged product.
+
         This is similar to a session merge except no database changes are done
         and the matchers are more deeply merged.
 
@@ -444,6 +495,13 @@ class LabelMatch(Base, Match):  # pylint: disable=too-few-public-methods
     name: MappedColumn[str] = mapped_column()
     is_pattern: MappedColumn[bool] = mapped_column(default=False)
 
+    def equals(self, other: "LabelMatch") -> bool:
+        """
+        Check if the label matcher is the same as another.
+        """
+
+        return self.name == other.name
+
     @validates("name")
     def set_is_pattern(self, key: str, value: str) -> str:
         """
@@ -477,6 +535,13 @@ class PriceMatch(Base, Match):  # pylint: disable=too-few-public-methods
     value: MappedColumn[Price] = mapped_column()
     indicator: MappedColumn[str | None] = mapped_column()
 
+    def equals(self, other: "PriceMatch") -> bool:
+        """
+        Check if the price matcher is the same as another.
+        """
+
+        return self.value == other.value and self.indicator == other.indicator
+
     @override
     def __repr__(self) -> str:
         return (
@@ -501,6 +566,13 @@ class DiscountMatch(Base, Match):  # pylint: disable=too-few-public-methods
     product: Relationship[Product] = relationship(back_populates="discounts")
     label: MappedColumn[str] = mapped_column()
     is_pattern: MappedColumn[bool] = mapped_column(default=False)
+
+    def equals(self, other: "DiscountMatch") -> bool:
+        """
+        Check if the discount matcher is the same as another.
+        """
+
+        return self.label == other.label
 
     @validates("label")
     def set_is_pattern(self, key: str, value: str) -> str:

--- a/rechu/models/shop.py
+++ b/rechu/models/shop.py
@@ -39,6 +39,23 @@ class Shop(Base):
         lazy="selectin",
     )
 
+    def equals(self, other: "Shop") -> bool:
+        """
+        Check whether the shop has the same fields as another shop.
+        """
+
+        for field, meta in self.__table__.c.items():
+            if not meta.foreign_keys and getattr(self, field, None) != getattr(
+                other, field, None
+            ):
+                return False
+
+        patterns = [indicator.pattern for indicator in self.discount_indicators]
+        other_patterns = [
+            indicator.pattern for indicator in other.discount_indicators
+        ]
+        return sorted(patterns) == sorted(other_patterns)
+
     def copy(self) -> "Shop":
         """
         Copy the shop.

--- a/samples/new/product_db_merge_input
+++ b/samples/new/product_db_merge_input
@@ -1,11 +1,14 @@
 # /#Chained from receipt_input with confirm mode on/x
 n                   # /Confirm .* write the completed receipt/
 m                   # Menu
-brand				# Metadata key
-CrispCrops			# Brand
+brand               # Metadata key
+CrispCrops          # Brand
 label               # Metadata key
 weigh               # Label
 1                   # Confirm merge by ID (1 or negative to add to range)
                     # empty or 0 skips meta
+m                   # Menu
+e                   # Metadata key
+?                   # ? menu
 w                   # Menu
 y                   # /Confirm .* write the completed receipt/

--- a/samples/new/receipt_valid_input
+++ b/samples/new/receipt_valid_input
@@ -24,7 +24,7 @@ price            # Metadata key
 discount         # Metadata key
 jazz             # Discount
 brand            # Metadata key
-BigChoc          # /Brand# currently matches but is not saved due to discount/x
+BigChoc          # Brand
 sku              # Metadata key
 abc123           # Shop-specific SKU
 -1               # /Confirm merge by ID \([^0].*or negative to add to range\)/
@@ -51,4 +51,5 @@ bulk             # Product
 over             # Discount label
 -0.22            # Price decrease
 due              # Product
-0                # /Metadata.*0 skips meta/
+e                # /Metadata.*edit/
+0                # /Metadata.*0 ends all/

--- a/tests/command/new/__init__.py
+++ b/tests/command/new/__init__.py
@@ -219,10 +219,13 @@ class NewTest(DatabaseTestCase):
             product_copy = match.copy()
             product_copy.id = product.id
             product_copy.generic_id = product.generic_id
-            if len(product_copy.range) != len(product.range):
+            root = product.generic if product.generic is not None else product
+            root_match = match.generic if match.generic is not None else match
+            if len(root_match.range) != len(root.range):
                 self.fail(
                     f"{item!r} should be matched to {match!r}, "
-                    + f"instead the match is {product!r} (missing range?)"
+                    + f"instead the match is {product!r} (root range has "
+                    + f"{len(root.range)} products vs. {len(root_match.range)})"
                 )
             for range_copy, range_item in zip(
                 product_copy.range, product.range, strict=True
@@ -230,8 +233,8 @@ class NewTest(DatabaseTestCase):
                 range_copy.id = range_item.id
                 range_copy.generic_id = range_item.generic_id
                 self.assertEqual(range_item.generic_id, product.id)
-            self.assertFalse(
-                product_copy.merge(product),
+            self.assertTrue(
+                product_copy.equals(product),
                 (
                     f"{item!r} should be matched to {match!r}, "
                     f"instead the match is {product!r}"
@@ -298,8 +301,8 @@ class NewTest(DatabaseTestCase):
                     ]
                     self.assertEqual(len(product_matches), 1)
                     match = product_matches[0]
-                    self.assertFalse(
-                        match.copy().merge(product),
+                    self.assertTrue(
+                        match.equals(product),
                         f"{product!r} is not same as {match!r}",
                     )
 
@@ -386,15 +389,20 @@ class NewTest(DatabaseTestCase):
                         _ = valid_file.write(line)
 
         with self._setup_input(Path("samples/new/receipt_valid_input")):
-            self._run_command(more=False)
-            self._compare_expected_receipt(
-                self.create, self.expected_valid, self.expected_products
-            )
+            with patch(
+                "subprocess.run", side_effect=self._edit_file
+            ) as edit_cmd:
+                self.replaces.append(("[jazz, disco]", "[jazz]"))
+                self._run_command(more=False)
+                self._compare_expected_receipt(
+                    self.create, self.expected_valid, self.expected_products
+                )
+                edit_cmd.assert_called_once()
 
     def test_run_product_db_merge(self) -> None:
         """
         Test executing the command with product metadata models stored in the
-        database, cuasing one of them to be merged.
+        database, causing one of them to be merged.
         """
 
         # Preload the products twice
@@ -406,11 +414,16 @@ class NewTest(DatabaseTestCase):
             Path("samples/new/product_db_merge_input"),
             start_inputs=(),
         ):
-            self._run_command(confirm=True)
-            self.products[0].brand = "CrispCrops"
-            self._compare_expected_receipt(
-                self.create, self.expected, self.expected_products
-            )
+            with patch(
+                "subprocess.run", side_effect=self._edit_file
+            ) as edit_cmd:
+                self.replaces.append(("brand: CrispCrops", "brand: PurePlants"))
+                self._run_command(confirm=True)
+                self.products[0].brand = "PurePlants"
+                edit_cmd.assert_called_once()
+                self._compare_expected_receipt(
+                    self.create, self.expected, self.expected_products
+                )
 
     def test_run_duplicate_product_meta(self) -> None:
         """
@@ -639,6 +652,20 @@ class NewTest(DatabaseTestCase):
                             portions=None,
                             sku="sp9999",
                         ),
+                        # Same as base
+                        Product(
+                            shop="inv",
+                            labels=[LabelMatch(name="bar")],
+                            prices=[
+                                PriceMatch(
+                                    indicator="2024", value=Price("0.01")
+                                )
+                            ],
+                            description="A Bar of Chocolate",
+                            portions=9,
+                            weight=Quantity("450g"),
+                            sku="sp900",
+                        ),
                         # Same as base except no GTIN (identifiers skipped)
                         # Did receive weight from merge
                         Product(
@@ -652,7 +679,6 @@ class NewTest(DatabaseTestCase):
                             description="A Bar of Chocolate",
                             portions=9,
                             weight=Quantity("450g"),
-                            sku="sp900",
                         ),
                     ]
                     matches = (

--- a/tests/command/new/input.py
+++ b/tests/command/new/input.py
@@ -2,6 +2,7 @@
 Tests for input source of new subcommand.
 """
 
+import sys
 import unittest
 from datetime import datetime
 from io import StringIO
@@ -121,6 +122,20 @@ class PromptTest(unittest.TestCase):
                 prompt.get_date(default=default),
                 datetime(2025, 6, 9, 12, 34, 0),
             )
+
+    def test_get_output(self) -> None:
+        """
+        Test retrieving an output stream to write content to.
+        """
+
+        self.assertEqual(Prompt().get_output(), sys.stdout)
+
+    def test_get_error_output(self) -> None:
+        """
+        Test retrieving an output stream to write error messages to.
+        """
+
+        self.assertEqual(Prompt().get_error_output(), sys.stderr)
 
     def test_get_completion(self) -> None:
         """

--- a/tests/database.py
+++ b/tests/database.py
@@ -8,7 +8,14 @@ from typing import cast, final
 from unittest.mock import MagicMock, patch
 
 from alembic import command
-from sqlalchemy import create_mock_engine, event, inspect, select, text
+from sqlalchemy import (
+    create_mock_engine,
+    create_pool_from_url,
+    event,
+    inspect,
+    select,
+    text,
+)
 from sqlalchemy.exc import DatabaseError
 from typing_extensions import override
 
@@ -51,6 +58,7 @@ class DatabaseTestCase(SettingsTestCase):
         super().tearDown()
         self.database.drop_schema()
         self.database.close()
+        self.database.engine.dispose()
 
 
 @final
@@ -67,11 +75,17 @@ class DatabaseTest(DatabaseTestCase):
         with self.database as session:
             self.assertIsNotNone(session.get_bind())
             self.assertIsNotNone(session.connection())
+            self.assertIn(
+                "Checked out connections: 1", self.database.engine.pool.status()
+            )
             with self.assertRaises(RuntimeError):
                 with self.database as session:
                     pass
 
         self.assertIsNone(self.database.session)
+        self.assertIn(
+            "Checked out connections: 0", self.database.engine.pool.status()
+        )
 
     def test_close(self) -> None:
         """
@@ -83,8 +97,35 @@ class DatabaseTest(DatabaseTestCase):
         with self.database as session:
             self.assertIsNotNone(self.database.session)
             self.assertEqual(session, self.database.session)
+            self.assertIsNotNone(session.get_bind())
+            self.assertIsNotNone(session.connection())
+            self.assertIn(
+                "Checked out connections: 1", self.database.engine.pool.status()
+            )
+
             self.database.close()
             self.assertIsNone(self.database.session)
+            self.assertIn(
+                "Checked out connections: 0", self.database.engine.pool.status()
+            )
+
+    def test_engine_pool(self) -> None:
+        """
+        Test opening a lot of connections to see if the pooling will not keep
+        too many open ones at the same time.
+        """
+
+        settings = Settings.get_settings()
+        pool = create_pool_from_url(settings.get("database", "uri"))
+        dbs = [Database(pool=pool) for _ in range(200)]
+        for db in dbs:
+            with db as session:
+                self.assertIsNotNone(session.get_bind())
+                self.assertIsNotNone(session.connection())
+                self.assertIn(
+                    "Checked out connections: 1",
+                    db.engine.pool.status(),
+                )
 
     def test_create_schema(self) -> None:
         """

--- a/tests/inventory/products.py
+++ b/tests/inventory/products.py
@@ -473,7 +473,7 @@ class ProductsTest(DatabaseTestCase):
         """
 
         product = self.inventory.find((MapKey.MAP_SKU, ("id", "abc123")))
-        self.assertFalse(product.merge(self.products[0]))
+        self.assertTrue(product.equals(self.products[0]))
         inv = self.inventory.find((MapKey.MAP_GTIN, ("inv", 9876543210321)))
         self.assertEqual(inv.shop, "inv")
         self.assertEqual(inv.gtin, 9876543210321)

--- a/tests/inventory/shops.py
+++ b/tests/inventory/shops.py
@@ -297,7 +297,7 @@ class ShopsTest(DatabaseTestCase):
         """
 
         shop = self.inventory.find("id")
-        self.assertFalse(shop.merge(self.shops[0]))
+        self.assertTrue(shop.equals(self.shops[0]))
         inv = self.inventory.find("inv")
         self.assertEqual(inv.key, "inv")
         self.assertEqual(inv.name, "Inventory")

--- a/tests/matcher/base.py
+++ b/tests/matcher/base.py
@@ -72,6 +72,7 @@ class MatcherTest(unittest.TestCase):
         one = TestEntity(id=1)
         two = TestEntity(id=2)
         self.assertIsNone(self.matcher.select_duplicate(one, two))
+        self.assertIsNone(self.matcher.select_duplicate(one, None))
         self.assertIs(self.matcher.select_duplicate(one, one), one)
 
     def test_match(self) -> None:

--- a/tests/matcher/product.py
+++ b/tests/matcher/product.py
@@ -309,6 +309,7 @@ class ProductMatcherTest(DatabaseTestCase):
         matcher = ProductMatcher()
 
         dupe = Product(id=99, shop="id")
+        self.assertIsNone(matcher.select_duplicate(dupe, None))
         self.assertIs(
             matcher.select_duplicate(dupe, Product(id=99, shop="id")), dupe
         )
@@ -695,6 +696,7 @@ class ProductMatcherTest(DatabaseTestCase):
 
         matcher.clear_map()
         self.assertTrue(matcher.add_map(copy(self.product)))
+        self.assertTrue(matcher.add_map(copy(self.product), True))
 
     def test_discard_map(self) -> None:
         """

--- a/tests/models/product.py
+++ b/tests/models/product.py
@@ -53,6 +53,66 @@ class ProductTest(DatabaseTestCase):
             range=[Product(shop="id", sku="5x"), Product(shop="id", sku="5y")],
         )
 
+    def test_equals(self) -> None:
+        """
+        Test determining whether the product has the exact same fields as the
+        other product.
+        """
+
+        self.assertFalse(self.product.equals(self.other))
+        same = Product(
+            shop="id",
+            labels=[LabelMatch(name="first"), LabelMatch(name="second")],
+            discounts=[DiscountMatch(label="one"), DiscountMatch(label="2")],
+            weight=Quantity("750g"),
+            volume=Quantity("1l"),
+            alcohol="2.0%",
+            sku="1234",
+            gtin=1234567890123,
+            range=[Product(shop="id", sku="5x"), Product(shop="id", sku="5y")],
+        )
+        self.assertTrue(self.other.equals(same))
+        self.assertTrue(self.other.range[1].equals(same.range[1]))
+
+        empty = Product(shop="id")
+        self.assertFalse(
+            Product(shop="id", labels=[LabelMatch(name="one")]).equals(empty)
+        )
+        self.assertFalse(
+            Product(shop="id", labels=[LabelMatch(name="one")]).equals(
+                Product(shop="id", labels=[LabelMatch(name="two")])
+            )
+        )
+        self.assertFalse(
+            Product(shop="id", prices=[PriceMatch(value=Price("0.12"))]).equals(
+                empty
+            )
+        )
+        self.assertFalse(
+            Product(shop="id", prices=[PriceMatch(value=Price("0.12"))]).equals(
+                Product(shop="id", prices=[PriceMatch(value=Price("1.23"))])
+            )
+        )
+        self.assertFalse(
+            Product(shop="id", discounts=[DiscountMatch(label="one")]).equals(
+                empty
+            )
+        )
+        self.assertFalse(
+            Product(shop="id", discounts=[DiscountMatch(label="one")]).equals(
+                Product(shop="id", discounts=[DiscountMatch(label="two")])
+            )
+        )
+
+        self.assertFalse(Product(shop="id", range=[empty]).equals(empty))
+        self.assertFalse(
+            Product(shop="id", range=[empty]).equals(
+                Product(
+                    shop="id", range=[Product(shop="id", description="bar")]
+                )
+            )
+        )
+
     def test_clear(self) -> None:
         """
         Test removing all properties of the product.
@@ -202,13 +262,23 @@ class ProductTest(DatabaseTestCase):
 
         self.assertFalse(self.product.merge(self.other))
 
-        less = Product(shop="id")
-        more = Product(shop="id", id=3)
-        self.assertFalse(less.merge(more))
-        self.assertEqual(less.id, 3)
+        id_less = Product(shop="id")
+        id_more = Product(shop="id", id=3)
+        self.assertFalse(id_less.merge(id_more))
+        self.assertEqual(id_less.id, 3)
+
+        brand_less = Product(shop="id")
+        brand_more = Product(shop="id", brand="foo")
+        self.assertFalse(brand_more.merge(brand_less))
+        self.assertEqual(brand_more.brand, "foo")
 
         with self.assertRaisesRegex(ValueError, ".*shop.*"):
             self.assertFalse(self.product.merge(Product(shop="other")))
+
+    def test_merge_price_match(self) -> None:
+        """
+        Test merging attributes of another product with price matchers.
+        """
 
         prices_indicators = [
             PriceMatch(value=Price("0.98"), indicator="minimum"),
@@ -398,6 +468,14 @@ class LabelMatchTest(unittest.TestCase):
 
     label: LabelMatch = LabelMatch(name="foo")
 
+    def test_equals(self) -> None:
+        """
+        Check if the label matcher is the same as another.
+        """
+
+        self.assertTrue(self.label.equals(LabelMatch(id=123, name="foo")))
+        self.assertFalse(self.label.equals(LabelMatch(name="bar")))
+
     def test_set_is_pattern(self) -> None:
         """
         Test determining if the label name is a regular expression matcher.
@@ -423,12 +501,54 @@ class LabelMatchTest(unittest.TestCase):
         self.assertEqual(repr(self.label), "'foo'")
 
 
+class PriceMatchTest(unittest.TestCase):
+    """
+    Tests for price model of a product matching value.
+    """
+
+    price: PriceMatch = PriceMatch(value=Price("0.12"), indicator="minimum")
+
+    def test_equals(self) -> None:
+        """
+        Check if the label matcher is the same as another.
+        """
+
+        self.assertTrue(
+            self.price.equals(
+                PriceMatch(id=123, value=Price("0.12"), indicator="minimum")
+            )
+        )
+        self.assertFalse(self.price.equals(PriceMatch(value=Price("0.12"))))
+        self.assertFalse(
+            self.price.equals(
+                PriceMatch(value=Price("1.23"), indicator="minimum")
+            )
+        )
+
+    def test_repr(self) -> None:
+        """
+        Test the string representation of the model.
+        """
+
+        self.assertEqual(repr(self.price), "('minimum', 0.12)")
+
+
 class DiscountMatchTest(unittest.TestCase):
     """
     Tests for discount label model of a product matching string.
     """
 
     discount: DiscountMatch = DiscountMatch(label="foo")
+
+    def test_equals(self) -> None:
+        """
+        Test checking if the discount matcher is the same as another.
+        """
+
+        self.assertTrue(
+            self.discount.equals(DiscountMatch(id=123, label="foo"))
+        )
+        self.assertFalse(self.discount.equals(DiscountMatch(label="bar")))
 
     def test_set_is_pattern(self) -> None:
         """

--- a/tests/models/shop.py
+++ b/tests/models/shop.py
@@ -39,6 +39,47 @@ class ShopTest(unittest.TestCase):
         )
         self.inv = Shop(key="inv", name="Inventory")
 
+    def test_equals(self) -> None:
+        """
+        Test checking whether the shop has the same fields as another shop.
+        """
+
+        self.assertFalse(self.shop.equals(self.other))
+        self.assertTrue(
+            self.shop.equals(
+                Shop(
+                    key="id",
+                    name="Generic Shop",
+                    website="https://shop.example",
+                    products="{website}/p/{category}/{sku}",
+                )
+            )
+        )
+
+        self.assertFalse(
+            Shop(
+                key="foo",
+                discount_indicators=[DiscountIndicator(pattern=r"[a-z]+")],
+            ).equals(Shop(key="foo"))
+        )
+        self.assertTrue(
+            Shop(
+                key="foo",
+                discount_indicators=[
+                    DiscountIndicator(pattern=r"[a-z]+"),
+                    DiscountIndicator(pattern=r"\d+%"),
+                ],
+            ).equals(
+                Shop(
+                    key="foo",
+                    discount_indicators=[
+                        DiscountIndicator(pattern=r"\d+%"),
+                        DiscountIndicator(pattern=r"[a-z]+"),
+                    ],
+                )
+            )
+        )
+
     def test_copy(self) -> None:
         """
         Test copying the shop.


### PR DESCRIPTION
- When merging into existing product metadata to change a field, matching with a product on the receipt, the write step indicates that the product is saved, however, such products are not written to their respective inventory YAML files. This is due equality check problems; do not use a merge for this as this skips checks for fields missing in the other product. Introduce equals methods for other models as well.
- Allow range product to be created/updated when the root (generic) or sibling range products match, but only accept the match if the current product also matches, to allow overshadowing from siblings.
- Track root product properly in metadata sets
- If none of the root product or range matches anymore, drop it properly
- Prefer edited non-final products during matching to avoid overshadows from database products as they may have changed and at least lost IDs; if we find a match then the original ID is copied over to allow update of existing products.
- More tests for editing of metadata, adjust tests and sample inputs for changes to which products and ranges are matched during overshadowing.
- Test prompt output/error output streams and duplicate select behavior when a product is missing (needed due to added complexity).