### PR TITLE
Avoid reading GTIN as octal integer and validate GTIN using  check digit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and we adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Avoid reading bare numbers with leading zeroes and no 8 or 9 in YAML product 
+  inventories as octal numbers, to support writing GTIN in this way.
+- GTIN from YAML product inventories is validated using the final check digit; 
+  if invalid, an attempt is made to correct octal conversion for the former but 
+  otherwise left untouched.
+
 ## [0.0.3] - 2026-05-15
 
 ### Changed

--- a/rechu/command/new/step/meta.py
+++ b/rechu/command/new/step/meta.py
@@ -662,9 +662,13 @@ class ProductMeta(DatabaseStep):
         elif input_type is not str and default is None:
             prompt = f"{prompt} (negative to cancel)"
 
-        return self.input.get_input(
+        value = self.input.get_input(
             prompt, input_type, options=options, default=default
         )
+        if isinstance(value, GTIN) and not value.validate():
+            LOGGER.warning("GTIN check digit incorrect: %s", value)
+
+        return value
 
     def _set_key_value(
         self,

--- a/rechu/io/base.py
+++ b/rechu/io/base.py
@@ -11,19 +11,21 @@ from datetime import datetime
 from enum import Enum
 from pathlib import Path
 from typing import (
-    cast,
-    Generic,
-    get_origin,
-    TextIO,
     TYPE_CHECKING,
+    ClassVar,
+    Generic,
+    TextIO,
     TypeVar,
+    cast,
+    get_origin,
 )
 
 import yaml
 from typing_extensions import is_typeddict
 from yaml.parser import ParserError
+from yaml.resolver import Resolver
 
-from rechu.models.base import Base, GTIN, Price, Quantity
+from rechu.models.base import GTIN, Base, Price, Quantity
 
 if TYPE_CHECKING:
     from _typeshed import OpenTextModeReading, OpenTextModeWriting
@@ -80,7 +82,24 @@ class Reader(Generic[T], metaclass=ABCMeta):
         raise NotImplementedError("Must be implemented by subclasses")
 
 
-class YAMLReader(Reader[T], metaclass=ABCMeta):
+class _YAMLResolver:  # pylint: disable=too-few-public-methods
+    _resolver_loaded: ClassVar[bool] = False
+
+    @classmethod
+    def _load_resolver(cls) -> None:
+        if cls._resolver_loaded:
+            return
+        pattern = re.compile(r"^\d{14}$")
+        for digit in "0123456789":
+            resolver = cast(
+                dict[str, list[tuple[str, re.Pattern[str]]]],
+                Resolver.yaml_implicit_resolvers,
+            ).setdefault(digit, [])
+            resolver.insert(0, (YAMLTag.STR, pattern))
+        cls._resolver_loaded = True
+
+
+class YAMLReader(Reader[T], _YAMLResolver, metaclass=ABCMeta):
     """
     YAML file reader.
     """
@@ -89,6 +108,8 @@ class YAMLReader(Reader[T], metaclass=ABCMeta):
         """
         Load the YAML file as a Python value.
         """
+
+        self._load_resolver()
 
         try:
             if is_typeddict(expected):
@@ -169,14 +190,14 @@ class YAMLTag(str, Enum):
     STR = "tag:yaml.org,2002:str"
 
 
-class YAMLWriter(Writer[T], Generic[T, RT], metaclass=ABCMeta):
+class YAMLWriter(Writer[T], _YAMLResolver, Generic[T, RT], metaclass=ABCMeta):
     """
     YAML file writer.
     """
 
     @classmethod
     def _represent_gtin(cls, dumper: yaml.Dumper, data: GTIN) -> yaml.Node:
-        return dumper.represent_scalar(YAMLTag.INT, f"{data:0>14}")
+        return dumper.represent_scalar(YAMLTag.STR, f"{data:0>14}")
 
     @classmethod
     def _represent_price(cls, dumper: yaml.Dumper, data: Price) -> yaml.Node:
@@ -195,9 +216,7 @@ class YAMLWriter(Writer[T], Generic[T, RT], metaclass=ABCMeta):
         Save the YAML file from a Python value.
         """
 
-        yaml.add_implicit_resolver(
-            YAMLTag.INT, re.compile(r"^\d{14}$"), list("0123456789")
-        )
+        self._load_resolver()
         yaml.add_representer(GTIN, self._represent_gtin)
         yaml.add_representer(Price, self._represent_price)
         yaml.add_representer(Quantity, self._represent_quantity)

--- a/rechu/io/products.py
+++ b/rechu/io/products.py
@@ -7,15 +7,15 @@ from datetime import datetime
 from pathlib import Path
 from typing import (
     Any,
-    cast,
-    final,
-    get_args,
     Literal,
     TextIO,
     TypeVar,
+    cast,
+    final,
+    get_args,
 )
 
-from typing_extensions import override, TypedDict
+from typing_extensions import TypedDict, override
 
 from ..models.base import GTIN, Price, Quantity
 from ..models.product import DiscountMatch, LabelMatch, PriceMatch, Product
@@ -116,6 +116,15 @@ class ProductsReader(YAMLReader[Product]):
         shop = data.get("shop", generic.get("shop", meta.get("shop")))
         if shop is None:
             raise TypeError("A shop must be provided for product")
+        if "gtin" in meta:
+            gtin = GTIN(meta["gtin"])
+            if (
+                not gtin.validate()
+                and (corrected := GTIN(f"{gtin:o}")).validate()
+            ):
+                gtin = corrected
+        else:
+            gtin = None
         product = Product(
             shop=shop,
             brand=meta.get("brand", generic.get("brand")),
@@ -135,7 +144,7 @@ class ProductsReader(YAMLReader[Product]):
             ),
             alcohol=meta.get("alcohol", generic.get("alcohol")),
             sku=meta.get("sku"),
-            gtin=GTIN(meta["gtin"]) if "gtin" in meta else None,
+            gtin=gtin,
         )
 
         product.labels = [

--- a/rechu/types/quantized.py
+++ b/rechu/types/quantized.py
@@ -25,6 +25,23 @@ class GTIN(int):
         del parts[-4::-8]
         return "".join(parts)
 
+    def validate(self) -> bool:
+        """
+        Determine if the global trade item number is valid based on the final
+        check digit.
+        """
+
+        digits = [digit for digit in reversed(str(self)) if digit.isdigit()]
+        # Include leading digits
+        result = 0
+        for digit in digits[1::2]:
+            result += int(digit)
+        result *= 3
+        for digit in digits[2::2]:
+            result += int(digit)
+        remainder = (10 - (result % 10)) % 10
+        return remainder == int(digits[0])
+
 
 class Price(Decimal):  # pylint: disable=too-few-public-methods
     """

--- a/samples/product-gtin-octal.yml
+++ b/samples/product-gtin-octal.yml
@@ -1,0 +1,4 @@
+shop: id
+products:
+  - gtin: 0555555555555
+  - gtin: 012345671234567

--- a/schema/products.json
+++ b/schema/products.json
@@ -123,9 +123,17 @@
                     "description": "The Stock Keeping Unit, i.e., a merchant-specific identifier for the product."
                 },
                 "gtin": {
-                    "type": "integer",
-                    "minimum": 10000000,
-                    "maximum": 99999999999999,
+                    "oneOf": [
+                        {
+                            "type": "string",
+                            "patttern": "^\\d{8,13}"
+                        },
+                        {
+                            "type": "integer",
+                            "minimum": 10000000,
+                            "maximum": 99999999999999
+                        }
+                    ],
                     "description": "The Global Trace Item Number of the product, expressed in 14 digits. This is the EAN-13 barcode with a preceding zero, the UPC with two preceding zeroes or the EAN-8 with five preceding zeroes."
                 }
             }

--- a/tests/io/products.py
+++ b/tests/io/products.py
@@ -167,6 +167,18 @@ class ProductsReaderTest(unittest.TestCase):
                     with self.assertRaisesRegex(TypeError, pattern):
                         self.assertIsNone(next(reader.parse(file)))
 
+    def test_parse_gtin_octal(self) -> None:
+        """
+        Test parsing an open file with GTIN values that look like octals.
+        """
+
+        path = Path("samples/product-gtin-octal.yml")
+        with path.open("r", encoding="utf-8") as file:
+            products = list(ProductsReader(path).parse(file))
+            self.assertEqual(len(products), 2)
+            self.assertEqual(products[0].gtin, GTIN(555555_555555))
+            self.assertEqual(products[1].gtin, GTIN(int("12345671234567", 8)))
+
 
 @final
 class ProductsWriterTest(unittest.TestCase):

--- a/tests/types/quantized.py
+++ b/tests/types/quantized.py
@@ -27,6 +27,17 @@ class GTINTest(unittest.TestCase):
         self.assertEqual(repr(GTIN(0)), "0")
         self.assertEqual(repr(GTIN(4241929)), "4_241929")
 
+    def test_validate(self) -> None:
+        """
+        Test determining the validiate based on final check digit.
+        """
+
+        self.assertTrue(GTIN(0).validate())
+        self.assertTrue(GTIN(36000241457).validate())
+        self.assertTrue(GTIN(3200000003774).validate())
+        self.assertTrue(GTIN(5901234123457).validate())
+        self.assertFalse(GTIN(10101010101).validate())
+
 
 @final
 class PriceTest(unittest.TestCase):


### PR DESCRIPTION
- When the number is represented in YAML with a leading zero and read in, the default YAML resolver for integers was taking precedence and made it an integer, and also converting to octal. To avoid this, prepend our implicit resolver, both during reading and writing, and write as string to avoid an explicit resolver on the string.
- If GTIN from YAML product inventories is invalid but the conversion back to octal leads to digits that are a valid GTIN, then it is read as the corrected GTIN.
- If GTIN from new subcommand meta input is invalid, then a warning is logged. No enforced exceptions causing rejection at this point.
- Test validation on some well-known GTIN examples
- Update schema to allow quoted GTIN in YAML product inventory
- Update CHANGELOG.md